### PR TITLE
Refactor workflow into modular step-based structure

### DIFF
--- a/utils/sim_runner.py
+++ b/utils/sim_runner.py
@@ -188,7 +188,7 @@ def extract_simulation_from_tex(tex_path: Path, sim_path: Path) -> bool:
         # Perform intelligent compatibility analysis
         compatibility = evaluate_simulation_compatibility(existing_content, py)
         
-        print(f"📊 Simulation Compatibility Analysis:")
+        print(f"Simulation Compatibility Analysis:")
         print(f"   Existing quality: {compatibility['existing_quality']:.3f}")
         print(f"   Extracted quality: {compatibility['extracted_quality']:.3f}")
         print(f"   Recommendation: {compatibility['recommendation']}")
@@ -198,20 +198,20 @@ def extract_simulation_from_tex(tex_path: Path, sim_path: Path) -> bool:
             # Create backup of extracted content for reference
             backup_path = sim_path.parent / "simulation_extracted_backup.py"
             backup_path.write_text(py, encoding="utf-8")
-            print(f"💾 Saved extracted LaTeX code to {backup_path.name} for reference")
+            print(f"Saved extracted LaTeX code to {backup_path.name} for reference")
             return True
             
         elif compatibility['recommendation'] == 'merge_possible':
             # For now, preserve existing but suggest manual review
             backup_path = sim_path.parent / "simulation_extracted_candidate.py"
             backup_path.write_text(py, encoding="utf-8")
-            print(f"🔄 Saved extracted code as merge candidate to {backup_path.name}")
-            print("💡 Consider manually reviewing and merging the best features from both")
+            print(f"Saved extracted code as merge candidate to {backup_path.name}")
+            print("Consider manually reviewing and merging the best features from both")
             return True
     
     # Use extracted simulation if no existing file or extraction is better
     sim_path.write_text(py, encoding="utf-8")
-    print(f"✅ Used extracted simulation code")
+    print(f" Used extracted simulation code")
     return True
 
 def run_simulation_with_smart_fixing(

--- a/workflow_steps/initial_draft.py
+++ b/workflow_steps/initial_draft.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from typing import Optional
+
+
+def generate_initial_draft(
+    topic: str,
+    field: str,
+    question: str,
+    user_prompt: Optional[str],
+    model: str,
+    request_timeout: int,
+    config,
+) -> str:
+    """Generate the initial paper draft."""
+    from sciresearch_workflow import (
+        _generate_best_initial_draft_candidate,
+        _initial_draft_prompt,
+        _universal_chat,
+    )
+
+    if getattr(config, "use_test_time_scaling", False) and getattr(config, "initial_draft_candidates", 1) > 1:
+        return _generate_best_initial_draft_candidate(
+            topic,
+            field,
+            question,
+            user_prompt,
+            model,
+            request_timeout,
+            config,
+            config.initial_draft_candidates,
+        )
+
+    return _universal_chat(
+        _initial_draft_prompt(topic, field, question, user_prompt),
+        model=model,
+        request_timeout=request_timeout,
+        prompt_type="initial_draft",
+        fallback_models=config.fallback_models,
+    )

--- a/workflow_steps/review_revision.py
+++ b/workflow_steps/review_revision.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+def run_review_revision_step(
+    current_tex: str,
+    sim_summary: str,
+    latex_errors: str,
+    project_dir: Path,
+    user_prompt: Optional[str],
+    iteration: int,
+    model: str,
+    request_timeout: int,
+    config,
+    pdf_path: Optional[Path],
+    output_diffs: bool,
+    paper_path: Path,
+) -> Tuple[str, str]:
+    """Run combined review and revision step."""
+    from sciresearch_workflow import (
+        _combined_review_edit_revise_prompt,
+        _universal_chat,
+        _parse_combined_response,
+        _apply_file_changes,
+        _revise_prompt,
+        _save_iteration_diff,
+    )
+
+    combined_response = _universal_chat(
+        _combined_review_edit_revise_prompt(current_tex, sim_summary, latex_errors, project_dir, user_prompt, iteration),
+        model=model,
+        request_timeout=request_timeout,
+        prompt_type="combined_review_edit_revise",
+        fallback_models=config.fallback_models,
+        pdf_path=pdf_path,
+    )
+    review, decision, file_changes = _parse_combined_response(combined_response, project_dir)
+
+    original_content = paper_path.read_text(encoding="utf-8", errors="ignore") if output_diffs else None
+
+    if file_changes:
+        _apply_file_changes(file_changes, project_dir)
+        if output_diffs and original_content is not None:
+            new_content = paper_path.read_text(encoding="utf-8", errors="ignore")
+            _save_iteration_diff(original_content, new_content, project_dir, iteration, "paper.tex")
+    else:
+        revised = _universal_chat(
+            _revise_prompt(current_tex, sim_summary, review, latex_errors, project_dir, user_prompt),
+            model=model,
+            request_timeout=request_timeout,
+            prompt_type="revise",
+            fallback_models=config.fallback_models,
+            pdf_path=pdf_path,
+        )
+        if revised.strip():
+            paper_path.write_text(revised, encoding="utf-8")
+            if output_diffs and original_content is not None:
+                _save_iteration_diff(original_content, revised, project_dir, iteration, "paper.tex")
+
+    return review, decision

--- a/workflow_steps/simulation.py
+++ b/workflow_steps/simulation.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Optional, Tuple, Any
+import os
+
+
+def run_simulation_step(
+    paper_path: Path,
+    sim_path: Path,
+    project_dir: Path,
+    model: str,
+    request_timeout: int,
+    python_exec: Optional[str],
+) -> Tuple[str, Any]:
+    """Extract and run simulation, returning summary and raw output."""
+    from sciresearch_workflow import _create_simulation_fixer, _extract_simulation_code_with_validation
+    from utils.sim_runner import run_simulation_with_smart_fixing, summarize_simulation_outputs
+
+    extract_success, extract_message = _extract_simulation_code_with_validation(paper_path, sim_path)
+    if not extract_success:
+        print(f" Simulation extraction issues: {extract_message}")
+    if os.getenv("OFFLINE_MODE") == "1":
+        print("Skipping simulation in offline mode")
+        simulation_code = sim_path.read_text(encoding="utf-8", errors="ignore") if sim_path.exists() else ""
+        return "Simulation skipped in offline mode.", {"stdout": "", "stderr": "", "return_code": 0}
+
+    simulation_fixer = _create_simulation_fixer(model, request_timeout)
+    sim_out = run_simulation_with_smart_fixing(
+        sim_path,
+        python_exec=python_exec,
+        cwd=project_dir,
+        llm_fixer=simulation_fixer,
+        max_fix_attempts=2,
+    )
+    simulation_code = sim_path.read_text(encoding="utf-8", errors="ignore")
+    sim_summary = summarize_simulation_outputs(sim_out, simulation_code)
+    return sim_summary, sim_out


### PR DESCRIPTION
## Summary
- Split monolithic workflow into dedicated step modules for initial drafting, simulation execution, and review/revision
- Orchestrate workflow via new module imports for clearer structure and maintainability
- Remove duplicate PDF review config field to avoid redefinition issues
- Add OFFLINE_MODE to return stub responses and skip heavy simulation during tests
- Mirror file logging to the console so workflow progress and messages appear in the terminal

## Testing
- `python -m py_compile sciresearch_workflow.py workflow_steps/initial_draft.py workflow_steps/simulation.py workflow_steps/review_revision.py utils/sim_runner.py`
- `OPENAI_API_KEY=*** OFFLINE_MODE=1 python sciresearch_workflow.py --output-dir output/ag-qec --modify-existing --max-iterations 1 --skip-reference-check --skip-figure-validation --disable-pdf-review --model gpt-4o-mini`


------
https://chatgpt.com/codex/tasks/task_b_68bbe3d65db8832abd28b4b5bd307f98