### PR TITLE
Add pytest coverage for file and LaTeX utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ Thumbs.db
 
 # Project specific temporary files
 test_*.py
+!tests/**/test_*.py
 simulation_output.txt
 error_correction_results.png
 *.tmp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for ensuring src package is importable."""
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,58 @@
+"""Tests for file management utilities."""
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from processing.files import FileManager
+
+
+def test_ensure_single_tex_file_creates_defaults():
+    """Ensure default files are created when none exist."""
+    manager = FileManager()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+
+        paper_path, sim_path = manager.ensure_single_tex_file(project_dir)
+
+        assert paper_path.name == "paper.tex"
+        assert sim_path.name == "simulation.py"
+        assert paper_path.exists()
+        assert sim_path.exists()
+
+        tex_contents = paper_path.read_text(encoding="utf-8")
+        py_contents = sim_path.read_text(encoding="utf-8")
+        assert "\\documentclass" in tex_contents
+        assert "Simulation code" in py_contents
+
+
+def test_ensure_single_tex_file_renames_existing_files():
+    """Existing .tex and .py files should be renamed to canonical names."""
+    manager = FileManager()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        custom_tex = project_dir / "custom.tex"
+        custom_py = project_dir / "model.py"
+        custom_tex.write_text("\\documentclass{article}", encoding="utf-8")
+        custom_py.write_text("print('hi')", encoding="utf-8")
+
+        paper_path, sim_path = manager.ensure_single_tex_file(project_dir)
+
+        assert paper_path == project_dir / "paper.tex"
+        assert sim_path == project_dir / "simulation.py"
+        assert not custom_tex.exists()
+        assert not custom_py.exists()
+
+
+@pytest.mark.parametrize("ext", [".aux", ".log", ".out", ".toc", ".bbl", ".blg", ".fls", ".fdb_latexmk"])
+def test_cleanup_temp_files_removes_auxiliary_files(ext):
+    """Temporary LaTeX artifacts should be cleaned up."""
+    manager = FileManager()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        temp_file = project_dir / f"paper{ext}"
+        temp_file.write_text("temp", encoding="utf-8")
+
+        manager.cleanup_temp_files(project_dir)
+
+        assert not temp_file.exists()

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,0 +1,116 @@
+"""Tests for LaTeX processing utilities."""
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock, patch
+
+from processing.latex import LaTeXProcessor
+
+
+MINIMAL_TEX = "\\documentclass{article}\\begin{document}Hello\\end{document}"
+
+
+def test_compile_and_validate_uses_cache_and_cleans_aux_files():
+    """Successful compilation should clean aux files and reuse cached result."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+        aux_file = project_dir / "paper.aux"
+        aux_file.write_text("aux", encoding="utf-8")
+
+        mock_result = MagicMock(returncode=0, stdout="compiled", stderr="")
+
+        with patch("processing.latex.subprocess.run", return_value=mock_result) as mock_run:
+            success, output = processor.compile_and_validate(paper_path)
+            assert success is True
+            assert "compiled" in output
+            assert not aux_file.exists()
+            mock_run.assert_called_once()
+
+            cached_success, cached_output = processor.compile_and_validate(paper_path)
+            assert cached_success is True
+            assert cached_output == ""
+            mock_run.assert_called_once()
+
+
+def test_compile_and_validate_failure_reports_errors():
+    """Failed compilation should surface combined stdout/stderr."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+
+        mock_result = MagicMock(returncode=1, stdout="warning", stderr="error")
+
+        with patch("processing.latex.subprocess.run", return_value=mock_result):
+            success, errors = processor.compile_and_validate(paper_path)
+            assert success is False
+            assert "warning" in errors
+            assert "error" in errors
+
+
+def test_compile_and_validate_handles_exceptions():
+    """Unexpected subprocess errors should be reported gracefully."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+
+        with patch("processing.latex.subprocess.run", side_effect=RuntimeError("boom")):
+            success, message = processor.compile_and_validate(paper_path)
+            assert success is False
+            assert "boom" in message
+
+
+def test_generate_pdf_for_review_success():
+    """PDF should be returned when compilation succeeds and file exists."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+        pdf_path = paper_path.with_suffix(".pdf")
+        pdf_path.write_text("pdf", encoding="utf-8")
+
+        with patch.object(processor, "compile_and_validate", return_value=(True, "")) as mock_compile:
+            success, resolved_pdf, errors = processor.generate_pdf_for_review(paper_path, timeout=42)
+
+        assert success is True
+        assert resolved_pdf == pdf_path
+        assert errors == ""
+        mock_compile.assert_called_once_with(paper_path, 42, force_recompile=True)
+
+
+def test_generate_pdf_for_review_handles_missing_pdf():
+    """A successful compile without a PDF should report the issue."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+
+        with patch.object(processor, "compile_and_validate", return_value=(True, "")):
+            success, resolved_pdf, errors = processor.generate_pdf_for_review(paper_path, timeout=10)
+
+        assert success is False
+        assert resolved_pdf is None
+        assert "PDF not generated" in errors
+
+
+def test_generate_pdf_for_review_failure():
+    """Compilation failures should propagate errors."""
+    processor = LaTeXProcessor()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        paper_path = project_dir / "paper.tex"
+        paper_path.write_text(MINIMAL_TEX, encoding="utf-8")
+
+        with patch.object(processor, "compile_and_validate", return_value=(False, "failure")):
+            success, resolved_pdf, errors = processor.generate_pdf_for_review(paper_path, timeout=10)
+
+        assert success is False
+        assert resolved_pdf is None
+        assert errors == "failure"


### PR DESCRIPTION
## Summary
- add a pytest configuration so the modular code under `src/` can be imported in tests
- validate `FileManager` file creation, renaming, and cleanup behaviours using `TemporaryDirectory`
- cover `LaTeXProcessor` compilation, error handling, and PDF generation logic with mocked `subprocess.run`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c92831faa8832a807a0362377bd43c