### PR TITLE
Handle pots without ranked eligible seats

### DIFF
--- a/src/poker_ai/rules/side_pots.py
+++ b/src/poker_ai/rules/side_pots.py
@@ -57,10 +57,12 @@ def distribute_showdown(
     total_seats = max(all_seats) + 1 if all_seats else 0
 
     for pot_amt, eligible in pots:
+        ranked_eligible = [s for s in eligible if s in ranks]
+        if not ranked_eligible:
+            continue
         # Find best rank among eligible seats
-        best = min((ranks[s], s) for s in eligible if s in ranks)
-        best_rank = best[0]
-        winners = [s for s in eligible if ranks.get(s, 10**9) == best_rank]
+        best_rank = min(ranks[s] for s in ranked_eligible)
+        winners = [s for s in ranked_eligible if ranks[s] == best_rank]
         share, rem = divmod(pot_amt, len(winners))
         for s in winners:
             payouts[s] += share

--- a/tests/side_pots_test.py
+++ b/tests/side_pots_test.py
@@ -19,3 +19,10 @@ def test_default_order_without_button():
     ranks = {0: 1, 1: 1}
     assert distribute_showdown(pots, ranks) == {0: 3, 1: 2}
 
+
+def test_pot_without_ranked_eligible_is_skipped():
+    """Pots with no ranked eligible seats should be ignored."""
+    pots = [(10, [1, 2]), (6, [0, 2])]
+    ranks = {0: 1}
+    assert distribute_showdown(pots, ranks) == {0: 6}
+


### PR DESCRIPTION
## Summary
- skip side pots whose eligible seats do not appear in the ranks map
- restrict showdown winner logic to ranked eligible seats
- add a regression test covering pots with no ranked players

## Testing
- pytest tests/side_pots_test.py

------
https://chatgpt.com/codex/tasks/task_b_68c9781649c0832a846f7f37abcc52e3