### PR TITLE
Improve seeding visibility and add tests

### DIFF
--- a/run_training.py
+++ b/run_training.py
@@ -1,20 +1,43 @@
 # (existing imports)
+import logging
 import os
 import warnings
+
+logger = logging.getLogger(__name__)
+
 try:
     import torch
-except Exception:
+except ImportError:
     torch = None
+    warnings.warn("PyTorch is not installed; torch-specific features are disabled.", stacklevel=2)
+except Exception:
+    logger.exception("Unexpected error while importing torch")
+    raise
+
 try:
     from poker_ai.utils.seed import seed_everything
-except Exception:
+except ImportError as exc:
+    warnings.warn(
+        f"Unable to import poker_ai.utils.seed.seed_everything: {exc}; seeding will be disabled.",
+        stacklevel=2,
+    )
     seed_everything = None
+except Exception:
+    logger.exception("Unexpected error while importing poker_ai.utils.seed")
+    raise
 
-def main():
+
+def main() -> None:
     # Respect deterministic runs if env var set
     base_seed = int(os.environ.get("POKER_AI_SEED", "0"))
-    if base_seed and seed_everything is not None:
-        seed_everything(base_seed)
+    if base_seed:
+        if seed_everything is not None:
+            seed_everything(base_seed)
+        else:
+            warnings.warn(
+                "POKER_AI_SEED is set but seed_everything is unavailable; skipping global seeding.",
+                stacklevel=2,
+            )
     # Optional: torch.compile for speed on PyTorch 2+
     if torch is not None and hasattr(torch, "compile"):
         try:
@@ -23,6 +46,7 @@ def main():
         except Exception as e:
             warnings.warn(f"torch.compile not enabled: {e}")
     # ... existing CLI + training startup ...
+
 
 if __name__ == "__main__":
     main()

--- a/self_play.py
+++ b/self_play.py
@@ -1,28 +1,67 @@
 # (existing imports)
+import logging
 import os
-from typing import Optional
+import warnings
+
+logger = logging.getLogger(__name__)
+
 try:
     from poker_ai.utils.seed import seed_everything, forked_worker_seed
-except Exception:
+except ImportError as exc:
+    warnings.warn(
+        f"Unable to import poker_ai.utils.seed utilities: {exc}; seeding will be disabled.",
+        stacklevel=2,
+    )
     seed_everything = None
     forked_worker_seed = None
+except Exception:
+    logger.exception("Unexpected error while importing poker_ai.utils.seed utilities")
+    raise
 
-def _maybe_seed():
+
+def _maybe_seed() -> None:
     base = int(os.environ.get("POKER_AI_SEED", "0"))
-    if base and seed_everything is not None:
-        seed_everything(base)
+    if not base:
+        return
+    if seed_everything is None:
+        warnings.warn(
+            "POKER_AI_SEED is set but seed_everything is unavailable; skipping global seeding.",
+            stacklevel=2,
+        )
+        return
+    seed_everything(base)
 
-def _worker_init(rank: int):
-    if forked_worker_seed is not None:
-        s = forked_worker_seed(int(os.environ.get("POKER_AI_SEED", "0")), rank)
-        seed_everything(s)
 
-def main():
+def _worker_init(rank: int) -> None:
+    base = int(os.environ.get("POKER_AI_SEED", "0"))
+    if not base:
+        return
+
+    missing = []
+    if forked_worker_seed is None:
+        missing.append("forked_worker_seed")
+    if seed_everything is None:
+        missing.append("seed_everything")
+
+    if missing:
+        warnings.warn(
+            "POKER_AI_SEED is set but the following seeding utilities are unavailable: "
+            f"{', '.join(missing)}; skipping worker seeding.",
+            stacklevel=2,
+        )
+        return
+
+    s = forked_worker_seed(base, rank)
+    seed_everything(s)
+
+
+def main() -> None:
     _maybe_seed()
     # When launching parallel self-play, ensure each worker calls:
     # _worker_init(rank)
     # (hook this into your mp.Process / DataLoader num_workers init_fn)
     # ... existing logic ...
+
 
 if __name__ == "__main__":
     main()

--- a/src/poker_ai/utils/seed.py
+++ b/src/poker_ai/utils/seed.py
@@ -1,32 +1,43 @@
 from __future__ import annotations
-import os, random
-from typing import Optional
+
+import logging
+import os
+import random
+import warnings
+
 import numpy as np
 
+logger = logging.getLogger(__name__)
+
+
 def seed_everything(seed: int, *, deterministic_torch: bool = True) -> None:
-    """
-    Set RNG seeds for Python, NumPy, and Torch (if available), including CUDA/MPS.
-    """
+    """Set RNG seeds for Python, NumPy, and Torch (if available), including CUDA/MPS."""
+
     random.seed(seed)
     os.environ["PYTHONHASHSEED"] = str(seed)
     np.random.seed(seed)
+
     try:
         import torch
+    except ImportError:
+        warnings.warn("PyTorch is not installed; skipping torch seeding.", stacklevel=2)
+        return
+
+    try:
         torch.manual_seed(seed)
         if torch.cuda.is_available():
             torch.cuda.manual_seed_all(seed)
-        # MPS / NPU backends (safe to call even if missing)
-        if hasattr(torch, "mps") and torch.mps.is_available():
+        if hasattr(torch, "mps") and torch.mps is not None and torch.mps.is_available():
             torch.mps.manual_seed(seed)  # type: ignore[attr-defined]
         if deterministic_torch:
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
     except Exception:
-        # Torch not installed or backend not available
-        pass
+        logger.exception("Encountered an error while configuring torch seeds")
+        raise
+
 
 def forked_worker_seed(base_seed: int, rank: int) -> int:
-    """
-    Derive a distinct child seed (e.g., for self-play workers or DataLoader workers).
-    """
+    """Derive a distinct child seed (e.g., for self-play workers or DataLoader workers)."""
+
     return (base_seed * 0x9E3779B1 + rank) & 0xFFFFFFFF

--- a/tests/seed_behavior_test.py
+++ b/tests/seed_behavior_test.py
@@ -1,0 +1,91 @@
+import builtins
+import os
+import sys
+import types
+import warnings
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT))
+sys.path.append(str(REPO_ROOT / "src"))
+
+from poker_ai.utils import seed as seed_module
+import self_play
+
+
+def test_seed_everything_warns_when_torch_missing(monkeypatch):
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    original_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch":
+            raise ImportError("torch is not installed")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    original_hash_seed = os.environ.get("PYTHONHASHSEED")
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            seed_module.seed_everything(123)
+    finally:
+        if original_hash_seed is None:
+            os.environ.pop("PYTHONHASHSEED", None)
+        else:
+            os.environ["PYTHONHASHSEED"] = original_hash_seed
+
+    assert any("PyTorch" in str(w.message) for w in caught), "Expected torch import warning"
+
+
+def test_seed_everything_reraises_on_torch_errors(monkeypatch):
+    fake_torch = types.ModuleType("torch")
+
+    def fail_seed(_seed):
+        raise RuntimeError("failure seeding torch")
+
+    fake_torch.manual_seed = fail_seed
+    fake_torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    fake_torch.backends = types.SimpleNamespace(
+        cudnn=types.SimpleNamespace(deterministic=False, benchmark=True)
+    )
+    fake_torch.mps = types.SimpleNamespace(is_available=lambda: False)
+
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    original_hash_seed = os.environ.get("PYTHONHASHSEED")
+    try:
+        with pytest.raises(RuntimeError):
+            seed_module.seed_everything(456)
+    finally:
+        if original_hash_seed is None:
+            os.environ.pop("PYTHONHASHSEED", None)
+        else:
+            os.environ["PYTHONHASHSEED"] = original_hash_seed
+
+
+def test_maybe_seed_warns_when_seed_function_missing(monkeypatch):
+    monkeypatch.setenv("POKER_AI_SEED", "99")
+    monkeypatch.setattr(self_play, "seed_everything", None, raising=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        self_play._maybe_seed()
+
+    assert any("seed_everything" in str(w.message) for w in caught)
+
+
+def test_worker_init_warns_when_utilities_missing(monkeypatch):
+    monkeypatch.setenv("POKER_AI_SEED", "100")
+    monkeypatch.setattr(self_play, "forked_worker_seed", None, raising=False)
+    monkeypatch.setattr(self_play, "seed_everything", None, raising=False)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        self_play._worker_init(rank=3)
+
+    assert caught, "Expected a warning when worker seeding utilities are missing"
+    assert any("forked_worker_seed" in str(w.message) or "seed_everything" in str(w.message) for w in caught)


### PR DESCRIPTION
## Summary
- warn when seeding utilities cannot be imported in `self_play` and `run_training`
- tighten `seed_everything` to only swallow missing PyTorch and surface other failures
- add regression tests ensuring warnings/exceptions are emitted when dependencies are absent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c97816b710832abf174c13581e9f2c