### PR TITLE
Add utility to export training proposal to PDF

### DIFF
--- a/OSS-120B_Training_Proposal.pdf
+++ b/OSS-120B_Training_Proposal.pdf
@@ -1,0 +1,241 @@
+%PDF-1.4
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /STSong-Light /DescendantFonts [ <<
+/BaseFont /STSong-Light /CIDSystemInfo <<
+/Ordering (GB1) /Registry (Adobe) /Supplement 0
+>> /DW 1000 /FontDescriptor <<
+/Ascent 752 /CapHeight 737 /Descent -271 /Flags 6 /FontBBox [ -25 -254 1000 880 ] /FontName /STSongStd-Light 
+  /ItalicAngle 0 /Leading 148 /MaxWidth 1000 /MissingWidth 500 /StemH 91 /StemV 58 
+  /Type /FontDescriptor /XHeight 553
+>> /Subtype /CIDFontType0 /Type /Font 
+  /W [ 1 [ 207 270 342 467 462 797 710 239 374 ] 10 [ 374 423 605 238 375 238 334 462 ] 18 26 462 27 28 238 
+  29 31 605 32 [ 344 748 684 560 695 739 563 511 729 793 
+  318 312 666 526 896 758 772 544 772 628 
+  465 607 753 711 972 647 620 607 374 333 
+  374 606 500 239 417 503 427 529 415 264 
+  444 518 241 230 495 228 793 527 524 ] 81 [ 524 504 338 336 277 517 450 652 466 452 
+  407 370 258 370 605 ] ]
+>> ] /Encoding /UniGB-UCS2-H /Name /F2 /Subtype /Type0 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 15 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/PageMode /UseNone /Pages 15 0 R /Type /Catalog
+>>
+endobj
+14 0 obj
+<<
+/Author (\(anonymous\)) /CreationDate (D:20250917073039+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20250917073039+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (\(anonymous\)) /Trapped /False
+>>
+endobj
+15 0 obj
+<<
+/Count 9 /Kids [ 4 0 R 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R ] /Type /Pages
+>>
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3355
+>>
+stream
+Gb!#^qf<E2')nH:@bA8oK\[m(@ifg'gT!MhE.B%8+f%5e\$:KDjN)rR]D:3j]-XjAp<5M<el?R`&0>U4Fgnrsrm\64"T1i+&#W:sGRua(a[iFFn33$*8fS:H78F0_rc_/l2j6)@P1E73fkSA0kRc86AUG$.8tHLs:15Ue.@Nl*377*aEit)>FeUd8Q&'@h<q7^V.XqC<3^g-WUsmYD&<6(RO8$,(,rKi>n\naIna-qnV\^7uEh-h0>f_!m4m=@r=b;X'CcmLX+/?Y*W(%<sMQ1?nb&!D8DQ]gPP#f_>)*T\q]`S9]l<5Q-g.\M78Qqh($PK6e'LB$MV8S(Y[)#i+Q"@8R---^_/9CbtoILe^H)'e4G&j!^(\ohT2p$-n!ni=b'XoF*7Ui-9U\F8-L3d1d(G5%ffK?#;<@iX\8nIsLZ]^8U^LV]lPL<YI2IgPuYrRka2>m(aRkngS40pQCE8\r%Vq!Z+Rr//9Mf50%nm_M">&ZWm=N@_qLqQ=:>saNGECe61:d^9ofJJRS<Wd_obq_I/29*1!dkTQ:HqTrCo#E0IN!`95YL5cX(Ch>P`2B[qF[Vif:bdB/G>.bgYl2jmbU73r7W%LGf+mYG(>>ckmKL"Qo_ZA>)Ec#OaLYp7r3uH,dsPe-PN7>"#AO#@1eo1;<GEL!8ZkoSMIh2"hcmtNK7"4McQblpVi4Kt^1P88%*h](!Uf7`I#m;RD5jt1-m5pR5Mh/kg#k7QH4$ssa`hu4(LW(f_l4A::8MYQZ?d0G!=Bu(BY;Y3+K18=:78/H:9J_[!IL1#U#bk.kdS5O;OsV,@dYhY;&p2l3I'.o[oXA6RrrE$%W[(K.1(XVGIJ6'k&O8]9r;^4.f"cKNDUot9JAeZi9n6hYAIc:O"[_?k>,lX"8L>\m\O@<Z0>`h`e?a+[J0P0_1-A0p,gC)o&VSY\r!TLSaI'E8>%+%YK/t[7/72LS!))89J4K48UaX*"d5acbQ=cFao]]PP!BO'<65KcR5-J"10'qVC.4.5'3C\MjW_1.7%;s<A4+^qPUfo!AXPcU7:F/CS.]uf=K)J]%$#5!p=1n:\W?]8SUVR&,WKVUAD%Co&,Zj%8MPLBho._qOg(Tt@.T&@5'JjYPFkdXT-*h:K?Y_Fr=e&h&?3_o#I>R;C)jgt'6-&g?G$Aj/B',l\un7gC<ci$HGe&HmbgI(Et"4Q&Vt]8oN40u$O%)197:3<3b"kSZ4((G+$"D6(HYGL0u7IgB;)RH4CXkFiJ;jZ)SY6f'5cK6$dDT.0[P<+bq![<$^7+q5qa1AYiC\]oniLC)G-4"a[\pk26$1N^XrGam$s9_"oQO2YZ@";[bt/nK?VDV+NSIJ/^NTglG4W))o=S1hcZ9Klb<HQk7i<`"uD5&V[`>U_p`?V`djs0,Be=;4u8q$TL("s*J=GNeZ%d3b:Mp-)_LN(>K#!V0!u7b@o\)tX[m*tTVe_Sbm_5mW*,!GB:T)"D*=gt:oD0ebD,*a$.RYN+d*tR1PGg?3;BDuXfUV_2ckQ]OcpqT+V.U+g<D^gB4+IaGVReBXL/P5Y&JOC>SIerbk._l!PhSC.L8dV0HS^'H;0@@%(QKD9H'7bZ=oS5(IM*o#cns&H.m"hOBj!0+[Gb*H"gXpSA,;Eknp>>H5I2-Pd"/mf:g6@6f,LG)h!Z[HBo0N=R5Ujl3Q*!jJ1GlF_)c3]?;.`)Y5kI2LO*+`:.rq*Fo`*q.%>34]0PC';t]OLelr-V<4c:Amc&olOAO%=_8gk8$4,H2,JQEV-_RFLpQU^Ng@Z(_c&9#!SuoK"FO0Gc5<)nT$0WQ9YgVb/$+sLTI@]r.(0?og/jn%0H4fIEM?8o]Bq54De;T<$h-GAPEogSA"&"5oJn]@HJI]YlLK:n57eQTkbBfl4oo2/+ZWm;HUsI(+s!0q;6'1F,sFa$"koIZ(lfo0>:F$%=<Z%I+<ef>]_9&lNch2u7a>8)*pR%a(CB>ZkJ;`IlcSU%UB'&6)95G!J'JOlYX?DhE(ESA6rT0!90>uqpEAt:`mhWH?FS65<Ar$eWqmCEhs3?o5c;<e_rPDYc_uL@_P>2u\+Ns]!(gahI!L;I/$cf^J4"G'Z)L:8Ug^4)<bMe^%?Qb+g;?7<<G=mF!r#s<af7MTN4b(hq@Za=Ie?Ho[0^7nOSKcAdb_B"=?5RVgK;KFbOc3?Dn5W,c,r15=Y`qD1&fS:jV'kAMajk2BB=!jr*N##%_D.#\bH;,j-uY$nB&gBX\C%V;<]Fl]o\8e%MssNOs\j5^C>4ISdPj%1g[TGfHN7<oQo3KW4"Q"JuOgF8ri0]ZHTi\A.5$pg,^NfS<hZ1A=&%3p,hudR*Ia\Khh*JUCG3W2/g8jn>s'l:TWH&l`\lAA>L&#o\YM6U"?EUnN^Ck'tX^XNra_34b#',PO3in0U$cl+XuG-['b2dPt8ls.<p*P^b^h=3QLo&Vg42U*MPRaoOXs#47nn$_O\"GH0VX"%neHKD-i=(o$l)mE,:B3N\/MjE,H!I.Loo9cRkmRKkh;^O;mV^28:BQqUPt.$p@(X#2l_IPOMQg`sK]\KAu$Mq$X<W%ocC:#7&k!ZSN`6BBVI_Y82gZ%<IsYea72Q62][/kBgeVDH0cQ.O3hWMbk)m?@OdOm.7?G@bCjCks?U@&)G1I"G_!'lM?-,3_uZN051L!&iqk3a6>18>u<JhKZOV'E6;>DJl=IBrPR?@>DJ"0;[uMjbk'J["kRGiKkTR>0mt&X^H:Ri+4NQh[Gc]n23A#mPUIV3RSKFB&<_3<_\HO`Y-]$O&c;-CQQ;@V2;>27^!_(>g)gS[h^I@&#u867(E=8kF`GrCHSoP4]#hf%eTkTcRk(hhNMQ[tjl0"iku%*oOpcP-Y!(hci)i%;K?IS(pfaK(O>[joHs8+JHf."XBT7/+MU_2%gS[NWR>BP=QdKQa]rn.&#-J(BgI`-6(dD+$$7IM[D9odqa%lRBqTe3`51RW\hh#-3aVA]MQ_0*X)HLUa\>;gO(*/dE]9cbo5Q"7mI#@i)V:i#HU&IS"S<SgI>;5R"Y=rY;@O7GG:2#SJG?Q_J?T\3`HAVCJD)sH6(ep31r6Lc6?A,o`.a?)ZaT(O50g07`43H!7oXTbu,us3Y%(pZ7:QkmY++,@6GZu7:#\&M2FPJCq:jIqI)hL=*7i`Bg(bZ236BVf&Q*JF5*ejd#(n!HSO(5/1H3!P=SssUl[kE2E[(X#!ZSug"'"rH^4cS9r&1MfqKsOj,cN6@ToO,OEF^E92-cMlhJ=#`DPd?&Con'kspDQpLpGN*@Bmu'W7eQ0:nG[pHDs!<hhR"kFT39?mcg73J<Y8KD^<<EA"5,WGWJcU-3)f\rT\Zd7D3^"Hr<Zn4NK*~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3332
+>>
+stream
+Gb!#^CK'!/')eD/Tks*sZC;6G6R)WRXhB:=^ht@NfEkA&R$TOsKJt&"AGPWII7?";fp6p=WiZuS?qW;NRI8P%:QLU"THB#6k9,ZE3mlH/N22=lH]a77j/DQ1HJ*R_nj!sR9bO;ebiJEgbVY<(cl0E*;Le#n!R9cpbsWoD*8&@:-<E=;^s?^ZHCW/8rAEkfi2;j[a_<hUda6UkDBol:2RT2%.<ugr6+CI;4O05A\VfKKY*>K&\;O,2>\Ne/0,HqlDBq/uRp<"9O$9AM'(VKpbkM["S%2uf4bZAPmr>L.fqM9^:,qX<W?3\Ob$\DQa`S4tqkAATbr.L6\V[h!k2qJhH%0=]Rmhf99fo,,q'i&uedR1QIZ#P+ZRjeC2<7N+leJJgqted%]XpP_=.?`U@_=4PF)B.tWc\;839bkG//oX"c+&&>bo:OSkQtHNfq:fYWF+@(];6Bj-2C;'ol[E[lC><fml>U9q`0\Ife7YCf:/FqUi(&>n;>f]"$o2l>K'VnNu@ZDYS#Y[ro3(%RjDqjeWgj*YDF*+BT#4+l@nHb3]97c33-7f0),mllj:naT-r^I@jN,aUd5M-m9HUNh>Sj+,MC;OHa1/S('g@!<`RiYA8ifqh5S?Nkk2>4qBT=&d+Dd%T!Nc>(W4C5hV&njB.jL5jd]6;MUe_D@^k$+ihjY4-Ll(>l'Wde@1RS-eZ=sPXa;!qi;:>5*u3L$@d69aanph$*I7D+mN(a9NfWM/7C5qo^NARYD?3E#:*HWKfjXL/@0aM,nhG^-Vqc*.o7`Z0+toUui[t/WIld:c^$Dk=q4M2-Iq>E]&mf'@_Fg[q+H?+86Jn`6c5=g=C*2k9-hOH!jKC6O!LO/)((7Bh]p\Br>,=u6A$hqI5n>eJX=rBnVsMl1"bI]SWm.G*`f@\`HJX>,"&[0.8gLCaoN'UC[4:.ma'N`8D%X:mctDe;0fhS1J4SG4k/a="k=5Zu?$b:s=$,m''LGOGc]%Z`q[kLZU`nuUkCsqfbbH#;Goh8n#"j:CJt(B+Gp=k(Xd8MSGg=R%?Z*["mVT6E!h%T"P*g_M'=5n$%L@DUU`<EQ;(_6sZYC2HO(WboN_F>q20;-eVL0#GCmG5Kd?(pjC_V%]d4N)Dd)+nL@3J@9Xu8'n6;1L,Hl'<1MD6ODdXJP"hk1L[ciAo,o_=dj[i:O.[C\0$\`XH&K"F(D>Sp`9c'#&h5JVW_b7AuK@ad9Bh-0gDJ>,r3_*/J2BugZI.5:c/>P=N=ELjY3<4qeUXr>B:*d*c"+D5BsjU%\dK_/f7R5WA_57liBVWNl@<V-6:ETYKJL<L_*S;_CeBFH(]N:9.sT096iAS:%8Y%$f0%p*R(PZ0@Wqi,oub6!0p";11?T?a.dD<p(?^HP%;-7Z$Y99++,45f1[Ng90jM^L[AZ,(p1KQi^M1<R5*U.tla<RYo\dZkNM1EHX^D@fUA.*R=566n>$F+G-3l.0[PrEWB33c1$mZoMF)Rm5osR30]rnS!CTMq@eMY4K[P$p;.GjRXZ-+6LYcL^I])/oMQ=<*-Mq$tgY7UU)miCS*q2V*pG*YYa7K?-/ZsR(kiV`,V1H7p/q^YrD//)cA+\C8LB[1P\6;bN+VnGD,@$5&IY[L`-mADs=b?)(T"%:7]lW8/0)l\#3D1jU/P3n!dTtCAedH?TBUJTM@46![UQr&bC!T-$Qr:XL:`tN^@/kcUj!SL[1P+cB3L[AV(jk6FH:Dla[h68"Mfgr3ZP<fH.6_Jon2f7h!g8D)Lc[5nO+!0?D#dfl3Sq14JO^K;09N\(4k4"1YW+k`tke)f;NF2B^c+0+TRkrPfA\RRKjE$OF\U9#c-lm!/`2d^<#5[@u3[5X^,fYeWNO8g0:Reeq,'^!,DdL"7;bTQA!Jn8K(BS<R@BBlQtf9+0o%-pQQiYLt^m)qD>Sp!G,2NND%Fe#I\Jbgl_(1d;8=5p+AFl4&NiMY9TPN\Nn5E\ndu&-_E<1S4GAq]KnIQ'+*USW#tUEC,ck@EC!T@lQf3KU/X$E_Mh0@)/ZT<e*F#nTI"WL1IBL1HtZ.L$P,Gab1E%ZJ[1[jtj_f$>/9BEau&W8T/^^R]1^8Ti<V_)LY,5S^$r:1g>V:ETl'8c)a(.fNb=4Wq66sZ%ZEZ*&j>QPGeRYF"dU5Z:^6^#=_AF:R`;p-%i]qr`ufV'#hC).fIY:)hPr;;j:(iEU'diLP:V8bP-?)-?/rn[8^),f-5gj,1Sd;6RXZO&k>aR6<I/O.-W`4lho41PU3B2V875QnJ3L:k<HF.p8/*Q#R:XInR*HYXjnPhUB'%Vpo<HP?l0W-N,`p%[(c1;*RMOJ-j2FMFUASR`TLP>!QC`6GLLTmJeu(>`Ji/mlf%tkNM%LjWK^2B&FaL<dOA*+`Q/iG!k^l2lMZb6Q._(jO(l]_Q\'DOr-s*r=h@7I^1J$!A1l<:Vq;<6BFY!GThZ1!=%`P(>BZKoW<Sbq&k$4!GB@n>b?@)rp%?](]dqq'H^;6nr#-fqK+e^se$ZYm._<1I"NOO/5Q:-u9O(8LI)F$QB9S0Gd,d&>:\dEei[)hr>VF"tge9#r:)FhRHd[I;$7!(3[<`$+9C\K+$53X'Fr#ShIJdG"e$2>d7G$4re^m(FL>FnnCpa-GLNhNe[i"">54&R%0#O.&A_ri'dpgGI^3V[$l)Pt^%5.qU!pt^AoR*aW$88W@(UjQPZ"N\58>pXs1U*Epj4m^CD9orffk`anB&U[ele#)#%tIhn.P\]B%lJ#/W7n$!_s+9QXi.@hYlGJ0=)L4%$7k>AancHJCgRAP=KKQSUiM4,h3#@6+aZHJl"[3eeKE7h^M5n&U:B7T_FOV`]V^Jb7U+8eJO.)UXH^XLri`E@1]3#`gSMBlZC0m2*#N1#QhhM#[H7Q^=1O!)PnTWVi(>3qdjnGi?BaK&6pbHSa5LN*6%@l<RkJO3aaQVQ#@cLOU-Bno=_3>*J.>JF;s&cfPb7*<E1!V>Dsbqf[<FM0+S:+1FQp:slO*Bk!FpZhjLUjI*#,2XGLj'/87=qn.=efb"Y:n#@htE5'Tsr@grLTZ>A&o18\^#lW`?-]50rA]OsWE3s$?i/<DFth@$e4mp^C&lALK/5nUZhlk&d>t+EsltnVrHqQ2EAD8:U'IG_>p7O=VCa6H%kW$*=(Tr;2"k82bJVS.dC(8tFfjrOW9!AXA0bXS3VNj:Z.[A*0-#Fopd:(TX\6*SQ_8C`DT>&lSRl1cq0anFeh_Y8UZr#^HTmeE<d2g!`J-7(BISjJ\EN:`fj*ZO26rYlf@N"?6[4#cD_Ij"$9.hN@_3%0D_!/MF5P/8FsGfCLZL%KD`n@ZC4LN#qm!o%YJn~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2705
+>>
+stream
+Gb!#]ku/6e'`[T.0j8.F\j.>n4c+Uh!HjYm85riK1PE[K6j1JOQbRt+HenXH-CGag;7g%324<^pS\KB-N!0&M)LI6:1uF:)QXh@Ae3/Uu4;16@f?n(%cIY/+X\;EQRc[;=d;6T.R"-c;:,\gll5iFCi3q;b'hO5e$2Q_$jBgLc;jie0;b;"lBqb8VTu>lu9PKc+/R%W\_]Y.<VNV^[b"Tj[>etmr9@=M$@sBo4CZ\n\j^ur#eWigAd=M8Yf?4p\e8(J0jnDH*GRIQkB<YJDZ%7PE+i.S#LREoppLD^$KNu"FYK48?jd\7S-'<6]Sfe4P1<>t]AMR!EBK3IL1:qTSJ`lJ#'kDN>]H4LX6=p=rdiP7I^&kKpTW?)O9et1tT.)!KhL11=GJa"lIqDm+EtnQkXOOV?Y(3qE(D*Gu/J)OJ_K.ca0CZGP71]*Lc?%^q_/oH+^4FMW+Q`s,2#`A8lM$4*f]5PZK=:7("o[*q4Nhd-]],fBQfU4,E*+'7=#_`>@8,E`HDYp9&\KQ#<.UAWE2roOLJr7R4NHD,80pP&DPM&o10^[dggo9YWrt"r0m=Gf][hr<T-T&%I(Pus$tXCnOX\aQb:Q[ueMVQBY&qA[I>0/R\#28r9g_qo)sc6t-i^X)Y=<6/[#KW*#G%lAIC9868MgQ)&,I!?J*_8Nn!7tgK#8e-Ok6>LZ?]\#Me=mYeMOe:0g$D)JYU3C;g3u8WRc/5?&+NCrPG^;E/$:!9st"Q@oE+48_ucmF:LIn/4GLB97JgMX.[ch*&Lqj&F^``rUK:c*G\ZYCK3$Ns,VW<O`U)(6G3%0=BlggIidN5RQn[J1rL2eOuM:GT*%-/Y[R]u5eL'R'\,G9*Pmpn?rMs,7tRbJTua*A]Ed2SmdL%/X_i;3SU*H7#1.pZiTrrE1fHY\=R79g0DLraL8Dup3^!S!V%dJgd9^93T]El7*_KUH,[[)Hp20d?9+jTgNn5<I#,3i?IDkXT!JbSQI,`1F>(UK`J)DWKZ#?S8ia+C+(&Gljr0Ct3C%8Bn5qegqSFDsE$ca!lVP\uX7j=1q.G![ul(ed0'?7XEk-\9tn9m?F"4!^pQF*6.CU5e'`iP9UAWR(-"r<gX17l#(oog?L:3%Z0g$9b2dC*U+IQEu=+9IW0%ggTGYieq_bZA6d&P+$MNN?M!@mte?MB9YiDD>^3?$?u+K,5NLF'NRYo$b0"C<"MGqHYEl&]H;p#"h32Nr$<L.J/RdN0qg(R*aRMH:7PK].8K1l;Se%Q.\\Z.OkVC7eG6Z&KfeqZMKMj1d$+$*f]I\E.69G:$V,.LVPHPF[LnM,PJqBmP>Bci-KX]"tPsQ0(]9F`+<6:kYocn*Lu'*"VX!c+hr`A)lPdY1T;KP[!2n4fCd7-.AROOXV.elHbj`s)]La:m%sWK7(^E[`LlR%=Rd8#O>1W75_9T'Lm)H@'\6=J9kTeQ=QMuk;PT.2N`^=fi?ALIY<BgRS"$HXq+--`Q-&Q0q#%pE`+RVk+4L$I+F@BjlP7C"&]5=%VVYqr4X=Yuh8'&F_?_H`K$,da;Ru721S7G[o*L@;_6bNUm1EIS^a'%1Pc$%&3cs]u#<"VY6.M'TbtPDM">S$Lo.I,&4W<C3fE]#JTCKjL@RaNMST@u#cc94T&WCL[Y,48'(3lXp3b6^a8e;2uDlM%96_+ZuI3EluF&lM(D]B>Jpa1fA9oku/p[YnEM$?C^-(ja/P/,i:Gd-ckCjd[&>gh_a1u'\,)r#u;boCE?mDsonankH#qSTkiEQQAR_TMEpFI@],@"D[peFS?uSO1:PA'&c4>]Mj(48dg7&D*skOpJ\V3)@pQBo<_m36fPb7l>30q^Y87Y%KQ$6m-RUlYVEWI7@/PE>X.8,$upTE#rK4$#>gU8;['AhbUS6C]YtjNE"e4>oiJENsKC(:#S6f)-JA4MC@k7e/6e7IBEms<G>+(f2\0nH$+PsE6WaG!pafbhh>NTY$R5VZ6PYH`&gjpYG7:u57)=H$p9!EH?WMa+4q^1d>Rq721Bbh-5:L<!O!HIZ=%'WhAZmiPi!LeE#*_B=Blgq5[40BW0']+j_(H5^paID/p'u.&0Z6og(d0=*W*LV7gj3a;GO3KH>^<D>37fQC\8I/)]9!="T1<c%dk_PIEm&ieGBKEa=*iGXm,,P(t3\?YRPDIhpCTtl0Eb4m,dgkl3Eq'd0gK+NhlB0PtiEj:/[Y)OIto&.!1WtNuT9qga3^fQfGGh<(?V3ht&eX="jSoEJtq0NV-P7eeU;+;"uVAFO/SPO3&>-,c12S<[Fp.ne&)^C928OX1p>@^Lk%?aY1bD*Ic(Sf.g=[5,nQ+2T,Z<OQe_b``@#KBIkI)"jmIU4F$#$OC\,G39&]O$$oOQgFMB!\JNIp'm1)iU6ehQQ#RU^TG.9hd,OT,[:NFSf#i^#TqjBt3SQoX;Fu$%,&hM3JBDi!hQ7U5a#tBE?:*me9>B0fq)MZt4?KG-,EQCN)F:3[R9!q\Z4O-Vf)G48ChPsB\\5M0Ak1t6=OnpQ+)s*4]$9G&@2-kK.^i@=\"X(l@]B0Q'I!].>oKB.9\>C50X5Qd`e.42&,U12_5Y`#73B*/\ShViW^O.=:5`2,b]TE>+Y(dWlC":2a^s5%HJMA[8eh-GUNA0YJH<cCbeh;I7+j<mC,+gg4>45u@79Q+]T#gp(#E`2AJ?LSDMtd'Zl9u!8n2^[k8tiEd$F~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2785
+>>
+stream
+Gb!#^=]='G&:WeDBX__,j8e>hN(i(6KTHYqp]*XSE5Z`)"I!Z3_Ig](hsMPbB4P5TTi-`*@ZWFp*8OtOI1.kDn0=oLpS-k?.p?&?O]53D@jL+13,5Qc03^74bfK-FA#%!+q+>5'!ae1tI$44U7S6.PSf:#C&./XRo^fI0c)*6f*_3>2*&I@d<jFCA%G\EV7+1(=$`bb?'$&rCr$1sYCc<*W1f>(3j4/%IXJOk\?;#F(UdD,F?6R6E2XB.7LfC<4<@YgHr/Ip`_WCoh2DuRlcE[3'?;V'e<Ua)<#\MS,,`TEmbn2j>*qBEZFifW8Mf)=pq+T+JNn0D-:?:sb]#-JZCh#8VbqdU<><-kJ\:r&kDqnL2:'pePW4ONA;qU;/WW_/3C8td'9=!qa)-WQLZ1bCVfY#D'YMXt#/B`'d\)AXc`9%GGm43*;inb/h>SdY/np:b4119(pW,JKR]PeE3O:H?2!`\LT;`"M,b=o]6e,mk3$ilueC74F*T)Q"$o2,)2=d0'W:OGf;MlJbR%1JAX`\RX);IeC4Y9[L&2V$tZ?%l=D.P5P]@%#>?kNQ`'-1]o0mX<ct&Wbadq!o.`6[T6\Y'&BNAq&+DL7uI::(]3A+_k#0/]uJF^b)^o0eBZ-OVq/eUUH&GgL9Ij1S#soRS[?hQ,l!kR=<-6l_GB6bq!VePDU\4Z3Kp<ZIA0El%u^QNVcdri)#6X;7%CX%hQ,F(JT-Yj?r=_=?0YlnIfQbX4Ws4,&Zs#E*`0%BZOgK4]jgo"S5_`(3HNd/?N#aV?]@O-QjR\QYNA5Z\iuiLfRVGD3iJ&,%o5I\&D7XSP\c,*p&1_+96jA3fIB!AYr7"/n"i^TWuOaqBJK%dK!HJHWjP2"[KU05Q2pC!KS"cqFqEqI[/4,1G>[R\N(rLpg2Q\0GXH]^Y->9CgRSJXNp-8@,p`\rXtZhA>Z(O4\/XA0r@T8l8Q5U@8Y!gS?3Sne1Hj#-IY,7E0mEQE:V:r&J.7#g.N1]@'H7G`&*71Y/+2mA$Y`7=el85W\AQ`J&$8cR?Oc^H^?\Q*]XY$mbrcY'Eog+'s0o;c,YOu<U0`PcQcN8'Vn2?ra,2Cd7F*?A&Q.qqa:?Ko63J,RAda&Z&?(ZEh!7`O[WYr@F+Z*3PN45UqIG=W>"/dn->`]C+>.jU0"!cK?TW$*^1LE:U"G@a;G(=)M?lLT5\aMAM%1'XdVeoZ\r<M5'NWQ3a64d'tKD1Xef_H5MGIS:U^YMQ5E#AL8;>?YYD)/rH^DmM&T;@<3M6715U?Q",9\f>UQ6;2AqUKMiRAV#rB?0@P&#[66H$ggg0U+boW;SUllLa+9Z*kf5I:cSb@i'NV"qbd0o#a;I^UE3qr]@KSE;ggD5M/g%GJ>cK?@4bqkDu9GhAHZ@"j@5gG8h\]D6BI&XK2p;*p0#XV@3?if:t5GPoGpNMHJ/Bje#i_)\E_kf\u_*XAqHj08NgRnsLX6Y.IT:`s:>itJF2A@jt.@@6'q\6K#a:gXMh/UDuXZNu?'P^H&"?7oJF&I'glLB&H.g@0?72rc\T>ad=_pn-RC[^AtP<.\V)T?#i,s(.g?>+bo7*;^sl=mt,pe-W)beWYN+h%Z\QV,>.>!l./Yj6u')654/@?C99aX,_0laKEU</@2doO=DnK1Lu2)GD*l0W[7d,(4a,pjtgIdt(=SY?8n70Pen=mgD=<->qfUH;"9Y9RPW=^u/&,(Ga@#_g.!&Eea&X5(jc;:-pAbV]a.4e3^DfKGaCe[?jb'UFXIYi2l%_&*0PHN(br0<*6^]F_DZLW,-ECXr7Ef41/=_n'In.Ddg"Lr3[`2OQ9I_?\G'rg/B2N(5?aNPFUb/46I)g8#Y)]kH&C'p_M]'@(*Ft`HGkoELmGsG)$aHCoi!5[ZjgA[4afhRiW>e8CL9GP;CFFjaNQSoMrTVR*Ds8RL#qp-VX+6n!.Lilp6Am3(-f"TlL/;7rnM!/_.Rk,)'krbn9YlXh.9lm\6.1de_o<M0oRcL"J?/XTu?CTZUur.9Y>QMUfKMF;dZE'o?1ol-u]ES?)WPi5#,h0H8%oP>#XFq-:ncQn4!u53iKBh2Rs9"\,X`1I!tS?q:/.n>Gn"SpF8,/L\t@Ib[Es@Z%fU&^hPYSi]HpXR6"SY[F]X&PQ.dJlq!aWQ(7S@(ROsGjP^V^g19.BbeAl&":Y"%=49"p%_N5T4(R3GWTHK@DqR]-T5(tJ60M#p&pM![3DMabE)K(J;BX2W/UV+QT$J[W*.<l1`IF5$nYOY,VZr;WIcpkr[tPPPL?0Tas7A!Jg<.1q_T?@k[_#PPmi2@11@]S/%GeE-2OQkVk"ie&.>)7Cld\W+.2ZP4W<0eT_T2]98EH#KX+^=l30+`4DhtKG!QVsG#sQ_FHmcIE<b2TdDgkkgUJf\*IgEp0gs>$H?p3(Qd,PnNS\<.F)9DHCf`4NXf$R.D[R.`bQQs!Uct*3pn%h:-)s)7#\RE).=<hu/j;AgMjc?KkY&1;s/q6;T.@4BhaWZNIhi*O<8i^"pIKOsX#s,(mG_ZX-)W0u%`g&bh[6-\0ePC^7NA9CB8>VDPs(=90dq4L@T:<=hf7(m[Yn!kpB@+ijrBR4KDS3KH!V^SJg_rbb1H3-dTNY0;J($;+31(2?sH=2PWNMNCdY]_(YB4o.9b\_;j=m63!S2"bsKH5IpE^rk2IOWghHq^MWQF=7"CtRClqJ0a27iF^^FZ;i(tk\^Z1c]5-NF!F4=2:7%Gn%Q&A&;M>c+Vj@'QC[^.P+]/Y#D(aUth\j1,n^Xa7:deZWoo0:!3!Aa~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2902
+>>
+stream
+Gb!#^qbnFo')k%D`T1e.P&+DhO-'WZX0.IJ*d\3J0b0_3M0V&bLKCd3=V<XjmG$H[=u0dg=E:l@;%_I/8?I>grH1nH,2bu>fK2ZfkNugZV+d[WgA?_#kL-1)2L3]!nEU2@<uRQ=7aEY;1`#!UR".]D>U**$BqMme"DsiO"$o.a#Kc!mB%`BDI>E69*g@'3aZ0HqgE.&Bn[\I^.ZkA<i>poZDTUp*#dKE-.Lp;8(?pM,.s7-m6E?;:gC+iid=]tPZd<E4]]3TMm%oCcPRoOHEOWD>m,G69-fFJ.#?im<K;;H#5:')o\A`]$?TMWORF;+1$O)#1@4r"jlk^N"<?Y<K&n\^TW&-%>I9;c*ch.WV`!'sg;-LM1-uIobM!t)d,&P.+.NCk"$Dh-"Am9%Z3ts%)H]]Kg;(_VOf+1/]fcFrS=C,+67<`>Y]Z3`G:]XZWLS(Tu8999n#.1*^B[M^Z^2a<Fcj-62'[3F>\M=9[koAj9qC6mB?ijQ`j1hW)fu.;?LK?I*YoeD6@5-sIgWs%=2`L]]A44f4Y]q/d"._o4+[@l35%2W_`8M\k,Q;pBK1DYSA\Xpmhh/biC/LKPL>tm\B9sJSONS?l5hlWZj2;]o>X!s9M%7Jl@`_Os@O?DYM"i_\AJ\n!M1U0!:*C81S>gh^gD3i4g*?(eKCUPsK<MD#^2:[kL_?8\d2c_]r<EF@qq37JXYjU"=5!NYJ3OR6\7?J421CM^]#FG8kjaR`[o,VqZK(\LpQ)$il(=[n":)L+.>-t7*;92<RhsPl&;LAemXca#o>,hrm]p3a/i+l-\kB2Ih"OqjFP&<dGepl(UieKUPi_2-FH$f2737\sEETuuat7![ZULlsB\X\rNgS)r+_Z6XMfU\7q&#/0&1lH`Sfe_K:q)ZBh1Wgb+qY),SINZp<ZXH[6s/e^!eS<M7^We+!*E.lm;IGJpDfKTh;9s?"8_mn&OfESU(mhS0j2SJ!(tjMBL[cNI7R-uG-;odORaAo7JF(m3DZ`klG2rPi-?Ri+GI%$VmIp5'86`<8^F4e@#.XI&e37X*0LeicSqKD2YBa1cKKCR2@a5V1&mI8YT+Y%V`@?X`$#6/M@MF>FPRca\f@1\b[!TXr)Lkt#$mX5%$]`3NO-2OA^":f.(Wf&4_(kqb\5NGKh`a;`aY7=F9'[[0B?!*.4-8)Bdm-63a-^]d:0o@fe%'"-*Mg+EFu&M\#@ts8..`J3*lTm2l+-5G5DY/`4Kd\,Y[QDrhE/s^`^O["34,i3?kU?U2&+6Q=oHsA]'5,Znf%phRjm]r`nY<1GrjrAKk"geS8L2bhV.LWOeI5cUk@(VINbA.ddo7lsedmp^lmG#HoN4GLIkm'o%M\U%0&CN<*W:OnUeS_^8&Z"r:Bh'X;$G5+Hb(3Og()-"L(t_jK+*D-c%,G,CX/VVTS4CqFfVK&seoMPU&8.6/eE3L@oF<*0Y(e>^4$G9gl4&&:(Ta?MQemTYg!,,0o"35/EUY@T"dGYf_PFI);1g89lTPm'B(Sre[t03-:aW]4,OZt*p:YO+J^KLhN8@!<LbnDPcERI#J"C[ZkN@B+f"V\/8PWZ:;L!)gH2kUT(b.V]`4/=r]5fqeq0+SJ$\3;>P/o;7_sg$K&'86sgJ`)%rLlk!!6,e/k0'm*\l4roI#hs]p*^$Q<G3JqBLd'4:q(e[7%;krY!>ZX7ZK!POH=o/MC02?tnSDM5@%,h6h.:eL2K&ZL,hk7&_9DfVE\^5@3_T`KNa?d01.OsS,A([FAXa1EDs1_0H$JfbnK.:^"K5:>i9'[u`1p,ITOfgCEnf*F+-2NI4=J+&%#r/L_C;MuVQ_0qcNd79,NnO6ncHUXt?(SRamnQK':i(+q;lRU?]mjH5i1CL`.tY`dqVsFcgKNoP_iCOMRGdL.%o8[;ltci.ID#c"8SdBOR5:(l503t'F+]77]i8\#a<CpE=TnOtp3UpS*ZcLMjorQ`bq<nlE(4L.2[TO5Vf=d(KP_R5D]*.+n?qqL,c1d$C>>RB^JEeUo!-c9*!f&62j\PBJs@)*miiHk;ipRaOiaQWW.LC(k9_C"D_L`i_(;S@VQ><Ie8&$LRtm1WB;3uu1i$s'5@?DFrMr$WlU\oXG&M/bqW3aTQE00sEN7S#kbDb@N'\PL998krma&BB%Xt%Eo,E>I1\l-'<i&:SkZ$9'>2uMcj'1";OLF([V9b2OhblTPHb@(p9r/A?F%ot\N90CI!c(ZG/(Z5R(k:8@&Q2WWSmP"2#5q<0XW#q0OH&KFmgtLX=rPXucD%;`0qib33N>Ae_k:WRa76eQ\Bh8e;"H+R(ik033_UA\p]D&oUY9\(S3(mCe'R;QdER1kBN'=."Xc-Vm[i7cp#'ua9rEYu.7>%7%H@1i)`J/9XNdI!/TUPrkL$,QR59c[O[?8XHPA$$h3&YMJ^sj:-q+HeQPWU0Rhk,oe<2(h4Z+9k2R^JdQ.N:ue+:]e<#S/q7+\%ZRi^=FZS[m!]"X$8F5o[GO^P^fBaKSj(?79qn[uej+5'4r0ghNQ1/gi5k8s6]D`lEVC:)/[`9kbHGo6OsO"Kn!XU9T;DtarjPB\H^C/`?s>E]SH`2l>J.),"OF%K3-MnP2M?GqB_-t#]g^42XH^OC;OVbI2?KS^#6A-[?ki#^)fM7S=qZ3(WJ#k;q$lqg&0J*h-uY@[V.$%8#s[2fXd_%Yi@B:/<s%HVN"])omb<:q62XJ.--=P2:DKO-i[Ej/cYI-"Ck2@a<]&aMH!1#fan(%\M^2UeghoIgbB3IpHS^"s*le!C>rkc"kr>/@:DF<#W^1.(?jHFu`UUltL1<P2-(s6SgLi:,>CmKr;[[4Q.e/!c.=Vt:%Dlju4iEeQDn^f]_C^)/t[pcEL'hm^E$k9079Q(TDb=(HDVm6%BNe)\=e"'e(4~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3177
+>>
+stream
+Gb!#^GuG[&'*$j]@`_8+E,=l$G'8C8]aFPO'jG.$!hn8&6XD%RL]i?H^uhu<m[e2qg6H338l8QI-1+BET>*S04C[g#C$hK\d98VXrgH>^7.$b*a3WbDr@WEHIe;5:DKi*+dXj\f>$>6a'CZ!^\7a!IP#;,#OC1IC+9=r](VOK*j'"[-g*]FtE0)a+PKsqjDh!RfK'/`?((o_#a&<7.R4Sf7i$sqJS]pJ6N:G/)4(CD@AjWaqp`[bTf'j'"cg1ff(V$!qo#WPC\@hPH52^I3b=>e]>W-T4`asZnmRd(j3VK7$rR\2:g[Z^%r4[5JlI^S1;G[7r(S7[%6cFku8V,oZTVk][1;Vr[HkU^lPe)E9L\TU65.,,,Xg.lub0<X-"K3u1/aYO@:h_rVf@@'u?e[e6Mp0jhCeO4GC7B,Bc"&&_*-dRMg4W8]4Nk1>"_%_H'9\^dksU^7fcAjZ,*?S7(2Og&H8>nZ4=3U%KV*>D4m=VD#Oi'P>FC:51ni$5CG"?(`/W__R9s.nHS8bG#EG#^]Rrn_[M*RQ-tJ3`7R;QlbTohP5,?C5;1K7(qQP[%qn`4\A)c:6N>3jDo8iALeY;]m$Cs2FgVs\4f!64P^i1hj0g,76M56cG[j1(OMunR,oTg18H/EGrG"'"oZ!%GQ^H-!M#+G#g^4-W_.MNb,^]_d;#XAZnn5k3r6p2Z+!-a<ahVK<P<pbKB:f!`N"]d=?FO7'85XgLV&D@paN'lB,H45(ObE[SR_$BrE+4[E'K__q_)FK#6D^3:As0`f-j,.%G%!pq"*CqD4H8l9e2M=jWrH)t2+9t7ar!]dU(lB"oi4]Vk,hiT0ep>W4Rp"<E$+@,Rn?D%Vms53J6ishX`N0&)@qc(5CFmmO$"8Fk!PMT_qdBV,bSI'oJ<Xk$'"fbV$6c'X!ssC848+T9Wrf(>+8Gm'IfU#l*E]"C^[Bl#M?ZGXYd[+gFIj$J;!*tGi=-b@#Sg6RY8j)D%4hP.+?JrZc]c9d8.^(+hJpVL2K3AWT2r@O'%pOnVR0,cK3ImOnSH[[^>bF9A9fo@+fIWMD^6NA"[j-:2]-5E>?F0<,*H4)Lc"salN10K*%?IMMj+7EZJ]5M8Gg1Sj<fa)V8->D>0m4:p)'uC:WWipV.AFMnt,[8T"fnPPJ*5*E!COp:j1g&lbJ!5Y,JV>$gm/r/,ri2*uk"7Mb'E7:B@Ku;Qflj^7#KVNU&<T`e=tc>C@V@ims0m-X2!MFCL0(!#/!k76tnBqZ(6u<>8X+('"5."(4Tr(cNc=U=e3FN3j10GdFeNggh`'h4LU<4md\9m*D"`e>,\NgL+L["0)k;Y#&LW0a)F3<^roZM.$p7&/J"/RoP9-%egIte.H0WNSMT(pk*Cl>?AA;U]f[A,DIb0UDU]R/0[e)m>;'EEXE"J!I]S[OO@*[:8H^fMP:M!"ef2*LsX?i*GHn0Wi`J.8jG?N[plK*U0m3_7_^tZrR"tG>_NlO21&n/<<RuA=fHC%n1crO,e`itITB<TKe3NnM@ZT9<+5B<),-WfM2#Sa2Agu(U4i4b2+(2B#_^LmG1UE,Nqa#J:t#B_oe(P4R3>Q.V0I.F!V[B-F-f!)F\Y)&]R//\7g+[0n2t85W0XukkbFC).`,Y[Oq'eS:gf[R$59l/e8?,]85.68rQuai:qL:ki""X@)_/oP*s&_PS+Lht,LspX""$gHAEYICB"IZ2(t[9mfc&HV0-2DiMAHXt:mrkJokeI^V,4:KV?m_`)O:.%U?Lhb0BC"WH0RW#Co)c,Cs`r!G(V>RCEmnVF;e.aq32r;Ng.<C_`_Q/HT!o.DQDnP+8mr^oG>Ou7.`QR/6$tG`<:dN+DmMrQ*Q)T/Va%^KVt`YaV_9sZgWkV[0GX%D_:"5TUG*3bSP]AE$SXLSJsG&Mg_'j&N&jB`Zk43iEgeBGAi6q(9,JPF.btl'rE-#kWhVI5+/I2I!QUAUusN,"pY*#N$L<A,#D--Fg\Q.T[R*Q&tR5YN0Q\kC'O[OpJW`T>s1fE'@str:NZILKt_\CFKo`'?'?M&f2h]fC&&ic6:/u>0+$">@PL8<5j,Vb?7.%k@Hg8YK&6@-WF.:^oaDRYQu/r%>^qQ&..kEC\":Bt-ZJ$/NDQJcYPjb`44)I&hC/$gZlIc&4@=#rQ"":UfEq1MCF?+H^fg1(K!RK5rSW'Fj!(-UpN.GM<dulN28KZ"EF`f3K/C!DYsbPMlJ#-TK]+DTR`V%*j"J'Q>"$O5<WLhDK>NFZ#/n-%)m[-bD8I0"@gi2Pg`I(XnEqWR.h7oB`FVYPj)o.9H\+/(a"b\U`,]_&rpP1=Nj?oKbD,[uO+*JY(]![*o`4dR2/T<1jU"AX<aE*N+G`(pFIdG<Dl&_d%"tRYWKtDm$dqJ%;1D'K,h[u)5RA'LUldc.G.Vt4bb+dPp?O>'2a\3##0q[?ZI<ZC.JmUMZ;=;CSH!N=K;dmeiuhcbM>'-rl4cOLmHdfM0tE%/VKX_C@:Me9P%GEBJi:S7ke9d&*dMnGhR8M]%Bs4(gmZrSqo\'EJ80VhG(6(&LaK3e3/fRQ6YaI*m5JY:)Wm;g%Bu9CXeCV`f5tr0^Hqhm]qH&FYqq'UDgSe["8\>,nmX\?&'2(hl#,f;o%4G>6]u5[YBX_"RHjqXh-oJH5kJM+9"u(GM9Vp]`Hn>`1BE[$q.4W2Y2,OLG.'Hf`2n.Mba"W#o!sKn9$LF?k`@5!Ds>^2)KXmSS54m?6Q/mV.\aK<7etI75]P*8#%f3AAo$AfTjZJEk$E@t[QM!qT'KBT%bO[*GJh[ha"Rct^Pi>="_>(@HMSF`Jl%Lo0ad=rj2TE9$TGD20):/a'eWK%H^M`j5=eOLZ?9jOjb+Vo-kP.(b[?Y!kt^BF.D_%I?>Rgld,+.%*bE)HlsT8^PXZo+0P8d+>ad.qEK)&h@bu[#WX\gW4LRIM>gp4Vn/,Ka@VJ'MINd@=q64A^EAl?mH2XQGk;ANbD,Y&e*Gi[8Q8CXo$oAWcXhR3M,_f'oY#&_cfr>=sX-BUiXbA[=U&uhO1g<[RJ1m0'V(t!KpcqUhULQ#CkP$e"TcHlRp**H#cHtGUK(U'BMJ-lg="H@!^ud+@/,`l*8WGtpl.@NG;YPc!"hZs`_VZ*_]*%g-Lj"gb02"Z,U@]$,7lLM%&WFp8.Eu6R`@C:,[^#K#o#kQ48!!W[FuKtH~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2282
+>>
+stream
+Gb!#]CNIs*&H2$(+dc[Vg617#lqI;-;B?uh7p%(T6j+LaZ$D]>*!hTS^V.60CTf!VIUq5b@:k@tqqO>]cJC&h#l#dhp*W/q<ugS^PCZ\!Hl>P^D1_O[E&V[IDoc'Sl[gg,D)[rd-M1t>V,t\-X7m&h00Y=50Wa?'@*Ar$U&s#d=d6c`b0O;>6mP+?08Wa#F!?i_-UKjJ>!5HAOb^QHB>[,kEr=j-&AJ_7?ZDXagk(cm?)u>_[H<e-$>d:AE.f?(d#t]j"C!Xl8TVb%\Sb$8rF"+jr"'A?l$-tVa5IX.:MH"E^Wk62M%V#[U$Zro-ed3JP&qB)"O/pX&K6DfPKX9@r9RGOE6_MQ)7HL)ia!oe%'seP792u$U:A9]RkAB'nNr%%C`]AI%F&`H,;_bEn'G=to\^kD:R"cA[\_p-4`3ghm[tHhMc]h"LWBF^NXFnWc2HF>l/6UU^O^pNh\L3E72OQpPUL6@i%O;f6oa!D-X)=UY7kG"0l#'#_f+rl%-"M!*'m5=%$-:-$q"]QTbY:(\52Klk[7COUld[3U>CBKJKb<-#Xe_[l0'rEd)^.pHUpDZ/i0[oK+<cEm[Z.!dm\?'Iec6XToJTs5'K(Ro-JGp[Si$hd@$Gf"0=)r\J<J(f)jhCE0c7J3K`FMGOV-"0Qg<eBdLL[;RA1a6EFRUqI?h]mA(f3/rRSc#Q5iR?TUid%L_eQ"MkMAhgKmoV8Mp(432:Y67[n;Tp]EWj!ipiib7A-"'fUE6PfXenPSOj-*Kj[C?$T&WK"@:`=7uS3@FRJF;TPWNGtJ+[=0%@[/ieo1Ig4'+f-J26\mtl?)[A]G)%kn^^T<bZc?3rH]GM>c?mc^o_A/CS`T$]=JXb37>@3#=SMX174Dp3Khrg"+5f4)*?2ea)ZQNh=u81b*2+OATsrA"J@Te[0`Nl=7_r%*#fRM]SVWa4rX$CO;J*f+.EQp#"p[i7'_huijFUr[a:_M\aTmR>Bi,[njg`P0l32M0\4I#cfdBf=[m7B\!/;2*KY!=Yko=S%nE?I[4%m/N&`O/?[8\TVY"@?D]VRR4>MoP7\."E.;!_VW2TA:)L7DfLduY6;,XSi0ncXmn!JIjH`.\fGdh-DW?u,@Y-&.9(r.F,I56bemU"SS8DP@`B.3\6n]^-,*4k&snflO7aMqelHb7,f"kPlW&o0t9U*WCsPpaNtk9D-3PQRAc1,A,bGOe%=HJi:'N6tOK@^hmuH09Z3?Po>k/8mlO-K#^td@`OE78B8nNbUFJYc?FdI4p'DQakP'kbmU;EVZHJR0sKl-dFdom=IIQ'OJL*mLOp]0k0[(`&Js"='91Q^3mtIAFA+4LoQ4Ifqcs0f1\'oc>c?.p$e;?t%@g;Ql@aA53]5XUTKK?rE`Ga9`N*:EY$o#p=rEaSjlWXW#3=<Yq\8/d-0k"TCtQu6"Ajf?0KaG`dr`s3B_>7&0].tl6:JOhn4.'?B:09#>Uj#e,pZXV.7L04S)fH`i-[in+>!l1pP@\#Ef9;2U.otn[hL9G(S,Hde7gcaGl]aiiHZch'(6Pq!/O4!lmoW(Re*2`G0l0n(;U='8O+Lm338,[YLaj*W7&@`/9hY^N4Qpoa?3p3$GPm^P>_5p2`l,tOmN^0lLr#Nnb<W,[#@Ef$eKG4ZUM*"FiTL7Y['[S%.Z8*d>U5N2Ds<\AQW5<M+YoW+T)(SMYV4N`\5."L6#nhp*Hm5n69&5QlA0qY-)5Z_9,F)-WH&5(H#i3rfSneijFVcf*@h)6\`'&$-[EhKXHcJ7[[>rK"W)[c,t,9bTZWJ!<mKuIrRC&j)"S;?784t+(%VVEZ[<%eGUu>gRhOKT'"8WcI5uF8_Udq<5Q/mUmf@BK'3]1Y`$TSO)dElMsEmpC3<5#h.NiA\c-&bWTm)1]AeI/g@e1kQ&@L;lF4@<aQ?::>Q42OfrF<M2LiV6<,UX<W`195Og-3i6=mNiMU-N0U;@eOR;ZEkc^rea`^7u\+psEB<U)<]HV@QYb]NL0j%ECE0]u,HPS^ek8&%Ud$)ssnXK,\BQVLEn[k(OHO_ti^<J-2e:T+i/1Ph>ibPn\IQt69>SKMOpob"1Zr,#NLaB4<3W.>?oXi1?l'G5m,lX/Bu$dE.DP,@BZc4:2DW4C0t(ETsZR*?;EZ'!3O=-jS9Id,OI;q4m_&H33]k<#V_q6nCC.W&'Co&nrVCS6_\Dt/E+qeh[IDT\-<Z8s[nEcg^nHrc/)(6tW.gfb=X.;M-J'<d+-"!=T$&=8S)iSi!mmN=M6k@:o2d"De14`a8R)F<CJ*H"/5~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3240
+>>
+stream
+Gb!#^qbu6?')k%DKm'Nb/phrR2)BOYFnYukCc8];4KQ1&"_,80ZFjXV+IfG0m5Nk,^6ZdECdTgO'O@"o1XjhOp")>O.F5JQMWOi*kH-"9lSmoSm3ROZ$CZO4]^hXA:Hh!?UF3t#Mke8R_SY;am9prMQb71_$bbUP)o:\L2"gV=YCGUr9iW25i[(41a?i,!OEGAop+eYt<(,PG^M-Im)?p;bXmD1JVl>^$<U0Gn%m/@6RQ+&jUY@'&;B7/=ol]a]eN,lgN=Pc)B@'4EjBJ=0jENi<b,eNsXLAOQK<J5@qfX/ns8?RUN_,b&3%**"iK6Z%oLPM3f05$!&n`I.,^q-2#Dq%X3a#glQ.7,9hS=3U,[PrrC"MV_e*h,d)WCjU-6"*'Vq:EZ1Kl#Ag:sr^N1/fhXmYJeXQTN<)m)!mb:_#odT*ssXV$hMKur!$i:9t%,N./IkqDq5%XmZf3&S_:K2CSH#rQb,s768;KsoUs[bA/QK0;;Ohn.ZV(UlT(-4!c/\+V9Lc(Zl:6%X)tf_?:@Ju5VtR-U*be@*.$g/^f5Z3ntJU]\?42U&\W`u_cb9c2TL7+N.9dnalggg_h'U<94*K&.CTI\h`P&juT-%6##=gW*9n9t[`F@jaD9@r0kl33>m59H-Zsp,tG.mF'sISOV)aCj!I$"gSLV?<T;X*'1Q1<FeLUk4(iojWJ'I=[]32/$/cX?&]0U_rK)r0t*r[hoK8bi\D,sA>7CS*"`>82[!NH\L=1fIdROQm";U2jE:RD9+jT5TFB?l>!)L*%0tgs2@67hf2_tem;<Y9YmF$6eGk@u<m>F/ZT!',ETZ/KE0ns^^Do<?1B[t$bf5IQV+b8+bs3F)>"d<Z,5m1G2.D$3hIrF%.hNLljOt]H-`uugbHqi^l"%iWJ>9Fl:IKO9LSqSfCWbVI??Yp#i38?!.H?:Am1uDkMQk*HB\QK'Bbc$""dgtTSnGbh%O]s"c)5cMZ\nqU(p>J>#BgSo)9h.UYKC!(QoAeMTi=-lP7@sqc95"rRdUEJ[l$1mRTXF9X`46GrIL<Vd'g/:_104_MD#Mq$-YbJM[=aKCL"h`>FYmhlcW0X*;sj),/T%jh"RS+auPqA\p"o@dI'mq7R*%Z/5\lfALaf;Af=)pF%pfi"lQI@^hb+bEen(tL'"A]6$*.5AU&euTp\bpNjYD(JCW%>At=A-]%$2]..d2j2JiRd\*!k*+=R@,FI3<Y@J"5hM%e=X49H<jLjHNl]Kt(/,p(3l.^ZpNLN(/VJ-`&gK?$AO?E:I.\\%nWHS3NZ9(Q`i6<Uj/oJWE1j$.-4i!.:#=13r[Y/g([^W*3Y8qLpad%e#Ap<M8@:Ln9G5jj'JWoD'/i]O#^-a7m6R%&!X.<Q(1[[s@/bEg8W8TM^E.;lF]lH5G:\MGb_Tt)bL!k[+u_?t=tYrUl0DgeVlj,JQ?'g#@l2*&tcV2FJ#ag/68WWuM5HHs^BFTs:?\jFCC40RsJ@1]Gq.dG%hcoT6_W-XR(bch?bA;iS8ep,?/!"mH<)k(tC]NYIUdNGr'9=K=K/:4>R(r]]ep1J'sFSn5gZ07-IA7i__i'/,tfRC:q\LcL'fYKL\q_i$+`gcSeGFA1>8r4+t]MdhLB8D&?]8p5=[Z6:*I'fPmN&=EBF3)O`hjo=ArbcdJ*#@$ri6of-NoonqR=&E;&;O"1^>P">FP_2BFc[b'[t8F]Hbd1H'6!'k=/3g[qe@c;H40Ub*bE4BD#6'r.;IK4;<$L^T0;KS&e0g3<_nMdc+LB\6WcLp[XCms7gZd[X]7\HN$i0DS#O/,12H(6WCggJ4Y$.19a'sAVR(t"?<-@oHo#coa%M>cZ*<l&@Z.&X*)Yf6CV106j/=H6cs`9slVQfo_.YPGNrbZL!Z>.GKS75%VC\2"bF%VH.b-q>SCb6mca>H5(L_`Bg#QHM&+b&D3adccYOG()`fNOpZ!i7RB0LX-5p2-`0A9AL0UI2@,Dk-Uk>hJkF!V6*7>"cbb4:5ucgfd>IN=RG;E"C`G.td@lrr81+/85.m+Oq^DqF4-.!rro[(J`C):WMf'gF-O\q)k0X%V+,U("^9KHuC?KiSZ\l=*ond-h)>S<nTh_1%a74"*>A/L.-JV-`.f"2L/Mq>^tPD\8>9(*Geg.?Km%+lAbLna9Z2mf$3e.Yi*YjI>TQ$YL2H%'#OWO*s.G64\)0!"IqD5(9%haK%\5:Ng8OCY%1"n*aYV,M:u_h1e2H`#,\UJ$HtZg'*9M_D4g?=pBUs^oU%npAbO\83b.+0o#+(,k:(M7_=D'A7\9m*d_I;n<=n'&lhY2Eo"UcP.,(Q/L6iYLM\rG&gOYb`pF=$Fj)/=EDOK#Y176\oa^Dd-]^%:`rJ7t\8Pj3DL'<>Y$0lcE%Cop336kFch1>,j<&qtY@8!`928dBWmH9#DkXL>Lkg#\PBSqXgfa;9LQgMIT=YWX%?cF'D]elh4,T+9Us@XOhs17j&nqj;-I>B_bdp>reVDP1Db_@t1pW+&dhK(:,-7N]VHKFLO>X-0#T?r625(_eIn&,T_/,gLW2^Q;J6sHn,IS-s:,YYT6(\[,n*K)1r"Su\]6cL4`U;1K@PM2klj3<hmSf'g;?il%oan9gdRu%l_2m*S+YMm,TtJ.%<udC*"&(^'YIBCQA,qHW.9b#jh[lonbNmEiE]Ra;[qQ?mQ=A(B%)i5@"L=&MS=RKdY@Ha"ZBVae&<[V"ndn_m7I-2QP1+`EZ3qD*H,MAu^=I\TbO5UGgTF4'#e=kY2CfjP-brjeQe_EYo<JQe+JnN[\6.bZ)->!/b4d7`8Q!Cr4fLSJ!2Q,6['0sF&ANnV<tEVrY@_MJfU9qt>/\K&9U$6iZFEcR^/GEjrOZ0&W[Rt9n73%pm$I1_ros]bCSLJ%eeOd@*Sr4r^(50`=4I4OjWpJ=b)(`RJ>8phl7cYUio)\,+Jn$GAol68S?HNf\8:<2H1,\r2Z(P0G6!9^a'$M%C3*P>!1.0+5%%6qTs)V%/_kDFV4*DM3FA97K4uCb:Fnsn$Soj./oP^^7lTTk-T&btI6?j1G0Z5AQoI/YX@9r6SoLhd_mu^n2Dc$5:'0Nokt>DZQr#8;?;-K`*m7^-!X;JOS((ciI])\7hdjLCfCo,;`T[!E":Ccfk+<?V368fYO7#Eg<@LX;`PdP;mhA!V^f5ml@Jm,BSRH'L7De-VSjK$\7-b0IF^X/F67V"!\3iI?Q5WSQ;c#QiEt8)W4Q[Gk>S)%J[pIpTrrEqU3'@~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 835
+>>
+stream
+Gatm:>Ar4L(k(RKGV?[.,)Mj@HeML8D,La1NRgk7g)s)l'dOfr?%;kORJ%JQ5W(SG*THO"qjbu-3:kX\CWtq"I7]j]jbsS5?8EW^!DAL,;;1m&i_P\F`1j'f,Y9@\)9SXN33"5I9BV7(Pid,mj.$I%qR7m(9WO9Lddt*m5u-o?E)1FC^^,r$-W5DV6:@a"O(7GMJrC@p-/]Q\*sl2f*uc1&QNSP/Bh(Ur+=L(E$B?QOSA7L\)9)eCijMT-!%'WI85Og]_uhASfHPpj%kPD&ks7,=LBM5m7g*OTS!Bn"alBndLWBma*5N,`arBP#E>A7%Od:XTH^cZO*#$Q3H3OkGYZ7W7F>>$9WJseS>D+nN-&*;i0TOrFF;q:/0Se7sO@],_,oh>L0Ltrb"Q+C&=<MI[ap=#ulZqr,X0p,q,r+#(YFr9'Qou3e@M^;$==:_+F"RXjcUL\Fq**%ZH$KSF%?ijj<[^s*n2N`t\&K:b>N6.#%F-k#9Pb=8<F_rFDu[@qe!a&DHj+P&n/d1Y`@>E#4cK1<4?gDID,]qDXe</`Or[sajuDTS6gQWq!HVgqm'rL-*M]0_k(55$U$?2QR*;?Z68JD`6jtF"eRR6q+r3E"BtZFCg9.0]<!Q="C&Nk:Bi4!fCD^l6CR)u^?n4L@iAX-.CS-ak/MY5WPD76B\i9@c#XW<5*tJ5`f^a<4WZ;H`*:/\A1B594#o6M+"NRBaDBFEQ$L!H902LCT]`['tIH_"7=/GooE%FEh][StA]bQKTHZjrXR^_Yce24R,P9dODe&9e*6H^(Z&O7kq6$8TeKi"D2"8/ub3Fa/'S:_Smr<<$=T5j~>endstream
+endobj
+xref
+0 25
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000001154 00000 n 
+0000001359 00000 n 
+0000001564 00000 n 
+0000001769 00000 n 
+0000001974 00000 n 
+0000002179 00000 n 
+0000002384 00000 n 
+0000002590 00000 n 
+0000002796 00000 n 
+0000003002 00000 n 
+0000003072 00000 n 
+0000003356 00000 n 
+0000003467 00000 n 
+0000006914 00000 n 
+0000010338 00000 n 
+0000013135 00000 n 
+0000016012 00000 n 
+0000019006 00000 n 
+0000022275 00000 n 
+0000024649 00000 n 
+0000027981 00000 n 
+trailer
+<<
+/ID 
+[<7f0a0f85d46ed73967ffe178895e4a67><7f0a0f85d46ed73967ffe178895e4a67>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 14 0 R
+/Root 13 0 R
+/Size 25
+>>
+startxref
+28907
+%%EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ google-generativeai>=0.3.0
 # Additional dependencies that might be needed
 requests>=2.25.0
 urllib3>=1.26.0
+reportlab>=4.4.3

--- a/utils/markdown_to_pdf.py
+++ b/utils/markdown_to_pdf.py
@@ -1,0 +1,271 @@
+"""Utilities for converting Markdown documents to PDF."""
+from __future__ import annotations
+
+import argparse
+import re
+from html import escape
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import A4
+from reportlab.lib.styles import ParagraphStyle, StyleSheet1, getSampleStyleSheet
+from reportlab.pdfbase import pdfmetrics
+from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+from reportlab.platypus import (
+    Paragraph,
+    Preformatted,
+    SimpleDocTemplate,
+    Spacer,
+)
+
+
+_HEADING_SIZES = {
+    1: 22,
+    2: 18,
+    3: 16,
+    4: 14,
+    5: 13,
+    6: 12,
+}
+
+
+def _register_fonts() -> None:
+    """Register fonts that support simplified Chinese text."""
+    # ``STSong-Light`` is bundled with ReportLab and provides wide Unicode coverage
+    # suitable for simplified Chinese content.
+    pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+
+
+def _build_styles() -> StyleSheet1:
+    styles = getSampleStyleSheet()
+    body = styles["BodyText"]
+    body.fontName = "STSong-Light"
+    body.fontSize = 11
+    body.leading = 16
+    body.spaceAfter = 10
+
+    styles["Normal"].fontName = "STSong-Light"
+    styles["Normal"].fontSize = 11
+    styles["Normal"].leading = 16
+
+    for level in range(1, 7):
+        style_name = f"Heading{level}"
+        if style_name in styles:
+            styles[style_name].fontName = "STSong-Light"
+            styles[style_name].fontSize = _HEADING_SIZES.get(level, 12)
+            styles[style_name].leading = styles[style_name].fontSize + 4
+            styles[style_name].spaceAfter = 12
+
+    bullet = ParagraphStyle(
+        name="BodyBullet",
+        parent=body,
+        leftIndent=18,
+        bulletIndent=9,
+        spaceAfter=6,
+    )
+    styles.add(bullet)
+
+    numbered = ParagraphStyle(
+        name="BodyNumbered",
+        parent=body,
+        leftIndent=20,
+        bulletIndent=9,
+        spaceAfter=6,
+    )
+    styles.add(numbered)
+
+    if "Code" in styles:
+        code = styles["Code"]
+        code.parent = body
+        code.fontName = "Courier"
+        code.fontSize = 9
+        code.leading = 12
+        code.leftIndent = 12
+        code.backColor = colors.whitesmoke
+    else:
+        code = ParagraphStyle(
+            name="Code",
+            parent=body,
+            fontName="Courier",
+            fontSize=9,
+            leading=12,
+            leftIndent=12,
+            backColor=colors.whitesmoke,
+        )
+        styles.add(code)
+
+    return styles
+
+
+def _format_inline(text: str) -> str:
+    text = text.strip()
+    text = escape(text)
+
+    # Bold / italics
+    text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
+    text = re.sub(r"\*(.+?)\*", r"<i>\1</i>", text)
+
+    # Inline code
+    text = re.sub(r"`([^`]+)`", r"<font face=\"Courier\">\1</font>", text)
+
+    # Links
+    text = re.sub(r"\[(.+?)\]\((.+?)\)", r"<link href=\"\2\">\1</link>", text)
+
+    # Collapsing multiple spaces that may appear after stripping markdown symbols.
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+_ListEntry = Tuple[str, int, str]
+
+
+def _flush_paragraph(paragraph_lines: List[str], flowables: List, styles: StyleSheet1) -> None:
+    if not paragraph_lines:
+        return
+    content = " ".join(paragraph_lines)
+    if not content.strip():
+        paragraph_lines.clear()
+        return
+    flowables.append(Paragraph(_format_inline(content), styles["BodyText"]))
+    flowables.append(Spacer(1, 6))
+    paragraph_lines.clear()
+
+
+def _flush_list(
+    list_items: List[_ListEntry],
+    flowables: List,
+    styles: StyleSheet1,
+    style_cache: dict[Tuple[str, int], ParagraphStyle],
+) -> None:
+    if not list_items:
+        return
+
+    for marker, indent, content in list_items:
+        style_key = ("BodyBullet" if marker == "•" else "BodyNumbered", indent)
+        if style_key not in style_cache:
+            base = styles[style_key[0]]
+            style_cache[style_key] = ParagraphStyle(
+                name=f"{style_key[0]}-{indent}",
+                parent=base,
+                leftIndent=base.leftIndent + indent,
+                bulletIndent=base.bulletIndent + indent,
+            )
+        style = style_cache[style_key]
+        flowables.append(
+            Paragraph(
+                _format_inline(content),
+                style,
+                bulletText=marker,
+            )
+        )
+    flowables.append(Spacer(1, 6))
+    list_items.clear()
+
+
+def _flush_code_block(code_lines: List[str], flowables: List, styles: StyleSheet1) -> None:
+    if not code_lines:
+        return
+    flowables.append(Preformatted("\n".join(code_lines), styles["Code"]))
+    flowables.append(Spacer(1, 6))
+    code_lines.clear()
+
+
+def _parse_markdown(lines: Iterable[str], styles: StyleSheet1) -> List:
+    flowables: List = []
+    paragraph_lines: List[str] = []
+    list_items: List[_ListEntry] = []
+    style_cache: dict[Tuple[str, int], ParagraphStyle] = {}
+    code_lines: List[str] = []
+    in_code_block = False
+
+    for raw_line in lines:
+        line = raw_line.rstrip("\n")
+        if in_code_block:
+            if line.strip().startswith("```"):
+                _flush_code_block(code_lines, flowables, styles)
+                in_code_block = False
+            else:
+                code_lines.append(line)
+            continue
+
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            _flush_paragraph(paragraph_lines, flowables, styles)
+            _flush_list(list_items, flowables, styles, style_cache)
+            in_code_block = True
+            code_lines.clear()
+            continue
+
+        if not stripped:
+            _flush_paragraph(paragraph_lines, flowables, styles)
+            _flush_list(list_items, flowables, styles, style_cache)
+            continue
+
+        heading_match = re.match(r"^(#{1,6})\s+(.*)", stripped)
+        if heading_match:
+            _flush_paragraph(paragraph_lines, flowables, styles)
+            _flush_list(list_items, flowables, styles, style_cache)
+            level = len(heading_match.group(1))
+            text = heading_match.group(2).strip()
+            style_name = f"Heading{level}"
+            style = styles.get(style_name, styles["Heading6"])
+            flowables.append(Paragraph(_format_inline(text), style))
+            flowables.append(Spacer(1, 8))
+            continue
+
+        list_match = re.match(r"^(\s*)([-+*]|\d+[.)])\s+(.*)", line)
+        if list_match:
+            _flush_paragraph(paragraph_lines, flowables, styles)
+            indent_spaces = len(list_match.group(1))
+            marker_raw = list_match.group(2)
+            content = list_match.group(3)
+            marker = "•" if marker_raw in {"-", "+", "*"} else marker_raw
+            list_items.append((marker, indent_spaces, content))
+            continue
+
+        # Default: accumulate into current paragraph.
+        paragraph_lines.append(stripped)
+
+    _flush_code_block(code_lines, flowables, styles)
+    _flush_paragraph(paragraph_lines, flowables, styles)
+    _flush_list(list_items, flowables, styles, style_cache)
+    return flowables
+
+
+def convert_markdown_to_pdf(source: Path, destination: Path) -> None:
+    if not source.exists():
+        raise FileNotFoundError(f"Markdown file not found: {source}")
+
+    _register_fonts()
+    styles = _build_styles()
+
+    with source.open("r", encoding="utf-8") as fh:
+        flowables = _parse_markdown(fh, styles)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    doc = SimpleDocTemplate(
+        str(destination),
+        pagesize=A4,
+        topMargin=50,
+        bottomMargin=50,
+        leftMargin=50,
+        rightMargin=50,
+    )
+    doc.build(flowables)
+
+
+def _parse_args(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Convert a Markdown file to PDF.")
+    parser.add_argument("source", type=Path, help="Path to the Markdown file")
+    parser.add_argument("destination", type=Path, help="Destination PDF path")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> None:
+    args = _parse_args(argv)
+    convert_markdown_to_pdf(args.source, args.destination)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a ReportLab-based utility that renders Markdown content with Chinese text into PDF format
- record ReportLab as a dependency and use the utility to produce `OSS-120B_Training_Proposal.pdf`

## Testing
- python -m utils.markdown_to_pdf OSS-120B_Training_Proposal.markdown OSS-120B_Training_Proposal.pdf

------
https://chatgpt.com/codex/tasks/task_b_68ca6288987c832a8e51a43d50202409