### PR TITLE
Introduce blueprint planning stage for higher quality drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,100 @@
-# SciResearch Workflow
+# AI Scientist Workflow
 
-A streamlined, modular research paper generation workflow with AI assistance.
+AI Scientist is an automated research assistant that plans, drafts, and iteratively polishes publication-ready papers. The workflow orchestrates ideation, blueprint planning, drafting, simulation, review, and rigorous quality validation so that every run produces a coherent LaTeX manuscript backed by executable evidence.
 
-## Features
+## Key Capabilities
 
-- **Modular Architecture**: Clean separation of concerns with organized source code
-- **Professional Logging**: Unicode-safe logging without emojis for clean terminal output
-- **GPT-5 Compatible**: Support for latest OpenAI models with automatic parameter handling
-- **LaTeX Processing**: Automatic compilation and error handling
-- **Quality Assessment**: Iterative improvement with comprehensive scoring
-- **Ideation System**: Generate and analyze multiple research ideas with scoring
+- **Blueprint-guided drafting** – automatically produces a structured research blueprint before writing begins. The draft generator is required to follow all [CRITICAL] and [IMPORTANT] items so sections, experiments, and visuals align with the plan.
+- **Document-aware prompting** – adapts prompts to the detected document type (research paper, survey, engineering report, etc.) and field-specific conventions.
+- **Simulation integration** – extracts, executes, and validates `simulation.py` blocks so figures and tables are tied to reproducible code.
+- **Iterative quality loop** – combines automated reviews, revision prompts, LaTeX compilation, and statistical rigor checks until quality thresholds are met.
+- **Content protection & auditing** – preserves previous drafts, enforces reference authenticity, and logs every change with optional diff artifacts.
 
-## Quick Start
+## Repository Layout
 
-```bash
-# Install the workflow as a package (run from the repository root)
-pip install .
-
-# Generate a new research paper
-sciresearch-workflow "Neural Networks" "AI" "How to improve training efficiency?" --output-dir out/neural_nets
-
-# Use GPT-5 with single iteration
-sciresearch-workflow "Quantum Computing" "Physics" "Quantum advantage?" --model gpt-5 --max-iterations 1 --output-dir out/quantum
-
-# Modify existing paper
-sciresearch-workflow --modify-existing --output-dir out/existing_paper --max-iterations 2
+```
+├── main.py / sciresearch_workflow.py      # CLI entry points and orchestration
+├── src/                                  # Modular workflow engine used by GUI and APIs
+│   ├── ai/                               # Chat interfaces and retry logic
+│   ├── core/                             # Config, logging, and workflow façade
+│   ├── processing/                       # LaTeX and simulation helpers
+│   └── legacy/                           # Historical monolithic workflow
+├── workflow_steps/                       # High-level pipeline phases (ideation, planning, drafting, review)
+├── prompts/                              # Prompt templates, blueprint planner, review enhancements
+├── quality_enhancements/                 # Validators, scoring metrics, hallucination guards
+├── ui/                                   # Desktop GUI built on the same workflow API
+├── out/ & output/                        # Example results and persisted run artifacts
+└── docs/                                 # Design notes and implementation walkthroughs
 ```
 
-### GUI Usage
+## Installation
 
-Prefer a graphical interface? Launch the desktop application after installation:
+```bash
+# (Optional) create a virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies and the workflow package
+pip install -U pip
+pip install .
+```
+
+The CLI entry point `sciresearch-workflow` becomes available after installation. For development you can also run `python sciresearch_workflow.py` directly from the repository root.
+
+## Command Line Usage
+
+```bash
+sciresearch-workflow "Neural Architecture Search" "Computer Science" \
+  "How can we reduce hardware cost while preserving accuracy?" \
+  --output-dir out/nas_study --max-iterations 3
+```
+
+Commonly used flags:
+
+| Flag | Description |
+| --- | --- |
+| `--disable-blueprint-planning` | Skip the new planning stage and draft immediately (default is to enable planning). |
+| `--draft-candidates N` | Generate `N` initial drafts with test-time compute scaling and select the highest quality version. |
+| `--use-test-time-scaling` | Enable multi-candidate revisions in later iterations. |
+| `--skip-ideation` | Use the provided topic/question without generating new ideas. |
+| `--enable-pdf-review` | Provide compiled PDFs to the reviewer model for layout-aware feedback. |
+| `--skip-reference-check` | Bypass external reference validation when you trust the citations. |
+
+Run `sciresearch-workflow --help` to see every option, including configuration file support and content protection controls.
+
+## Workflow Phases
+
+1. **Ideation (optional)** – Explores multiple angles for the topic and records the selected concept in `ideation_analysis.txt`.
+2. **Blueprint Planning** – Uses `prompts/planning.py` to create a Markdown blueprint with section priorities, experiment plans, and a checklist. Saved as `research_blueprint.md` in the project directory.
+3. **Initial Drafting** – `workflow_steps/initial_draft.py` combines the blueprint, document-type prompt, and user guidance to generate a LaTeX manuscript. When test-time scaling is enabled, multiple drafts are scored by `_evaluate_initial_draft_quality` and the best candidate is chosen.
+4. **Simulation Synchronization** – `simulation.py` is extracted, executed, and its outputs summarized. Failures halt progression so code stays reproducible.
+5. **Review & Revision Loop** – Each iteration compiles LaTeX, runs the quality validator, gathers reviewer feedback, and applies revisions. The loop stops early if the quality score plateaus or after `--max-iterations` passes.
+6. **Quality Validation** – `quality_enhancements/quality_validator.py` enforces statistical rigor, formatting rules, citation checks, and optional content protection thresholds before finalizing the paper.
+
+## Outputs
+
+Each run creates a timestamped project directory (or reuses an existing one when `--modify-existing` is set) containing:
+
+- `paper.tex` – the evolving manuscript.
+- `simulation.py` – executable experiment script extracted from the LaTeX source.
+- `research_blueprint.md` – the planning artifact that guided drafting.
+- `logs/` – timestamped workflow logs.
+- `diffs/` (optional) – review-to-review LaTeX diffs when `--output-diffs` is enabled.
+
+## Graphical Interface
+
+Launch the Tkinter-based GUI with:
 
 ```bash
 sciresearch-workflow-gui
 ```
 
-The GUI provides forms for every workflow argument, including checkboxes for boolean flags
-(`--skip-ideation`, `--enable-pdf-review`, `--disable-content-protection`, and more), numeric
-spinboxes for iteration counts and thresholds, and dropdowns populated from
-`document_types.get_available_document_types()`. Use the directory pickers to choose an output
-location, then monitor progress in the live log viewer while the workflow runs on a background
-thread. A Cancel button signals the workflow to stop after the current phase completes.
+The GUI mirrors every CLI option, including blueprint planning, and provides live log streaming with a cancel button.
 
-> **Note:** Tkinter ships with the standard Python distribution on Windows, macOS, and most
-> Linux environments. If your Python build omits Tkinter, install the appropriate package from
-> your system package manager (for example, `sudo apt install python3-tk`).
+## Extending the Workflow
 
-## Project Structure
+- Add new document templates in `document_types.py` and corresponding prompt logic in `document_prompts.py`.
+- Introduce additional validators under `quality_enhancements/` and register them inside `quality_validator.py`.
+- Customize prompts (or add organization-specific requirements) in the `prompts/` package. The blueprint planner can be adapted for new research domains by editing `prompts/planning.py`.
 
-```
-├── main.py                    # Main entry point
-├── src/                       # Core modular architecture
-│   ├── core/                  # Core workflow components
-│   ├── ai/                    # AI interface modules
-│   ├── latex/                 # LaTeX processing
-│   ├── quality/              # Quality assessment
-│   └── utils/                # Utility functions
-├── out/                      # Generated output papers
-├── docs/                     # Documentation
-├── utils/                    # Legacy utilities
-├── pyproject.toml            # Project metadata and dependencies
-└── requirements.txt          # Legacy dependency list
-```
-
-## Command Line Options
-
-- `--model`: AI model to use (default: gpt-4)
-- `--max-iterations`: Maximum revision iterations (default: 4)
-- `--output-dir`: Output directory for generated papers
-- `--skip-ideation`: Skip the ideation phase
-- `--user-prompt`: Custom prompt for AI interactions
-- `--verbose`: Enable detailed logging
-
-## Recent Updates
-
-- ✅ Professional logging without Unicode characters
-- ✅ GPT-5 API compatibility 
-- ✅ Modular architecture with clean imports
-- ✅ Robust LaTeX parsing and compilation
-- ✅ Comprehensive ideation system
-
-See `CHANGELOG.md` for detailed changes.
-
-## Legacy Files
-
-- `src/legacy/legacy_monolithic_workflow.py`: Original monolithic version (kept for reference)
-- `docs/archive/`: Detailed implementation documentation
-
-## License
-
-See `LICENSE` file.
+Pull requests and research contributions are welcome—see `CONTRIBUTING.md` if available or open an issue describing your enhancement idea.

--- a/core/config.py
+++ b/core/config.py
@@ -53,6 +53,7 @@ class WorkflowConfig:
     auto_approve_changes: bool = False
     fallback_models: List[str] = None
     max_quality_history_size: int = 100
+    enable_blueprint_planning: bool = True
     
     def __post_init__(self):
         """Initialize default fallback models if not provided."""

--- a/prompts/planning.py
+++ b/prompts/planning.py
@@ -1,0 +1,57 @@
+"""Prompt helpers for research blueprint planning."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Dict, List
+
+from document_types import DocumentType, get_document_template
+
+
+def get_blueprint_prompt(
+    doc_type: DocumentType,
+    topic: str,
+    field: str,
+    question: str,
+) -> List[Dict[str, str]]:
+    """Create a planning prompt that yields a structured research blueprint."""
+
+    template = get_document_template(doc_type)
+
+    system_prompt = dedent(
+        f"""
+        You are a principal investigator who specializes in outlining high-impact {template.doc_type.value.replace('_', ' ')}s.
+        Design a complete research blueprint that a writing model will follow when drafting the manuscript.
+
+        Planning expectations:
+        • Provide a hierarchical outline covering every mandatory section for a {template.doc_type.value.replace('_', ' ')} in {field}.
+        • Summarize the core thesis and 2–3 concrete contributions that answer the research question.
+        • Detail the methodology plan, including datasets or simulation ingredients, key techniques, and validation checkpoints.
+        • Specify quantitative evaluation strategy: metrics, baselines, ablation studies, and statistical tests that must appear.
+        • Identify figures, tables, and diagrams that must be produced, with one line describing the insight each visual conveys.
+        • Highlight potential risks, open questions, or assumptions that the draft must address explicitly.
+
+        Constraints:
+        • Keep the blueprint under 600 words.
+        • Use Markdown with numbered sections and sub-bullets.
+        • Label each major section with an explicit priority tag in brackets (e.g., [CRITICAL], [IMPORTANT], [NICE-TO-HAVE]).
+        • Reference recent seminal works or datasets by name only—do not invent citations.
+        • Emphasize reproducibility requirements relevant to {field} and the {template.prompt_focus} focus area.
+        """
+    ).strip()
+
+    user_prompt = dedent(
+        f"""
+        TOPIC: {topic}
+        FIELD: {field}
+        RESEARCH QUESTION: {question}
+
+        Produce the blueprint now. Close with a concise checklist summarizing the top five items the drafting model must satisfy.
+        """
+    ).strip()
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+

--- a/workflow_steps/initial_draft.py
+++ b/workflow_steps/initial_draft.py
@@ -10,6 +10,7 @@ def generate_initial_draft(
     model: str,
     request_timeout: int,
     config,
+    planning_brief: Optional[str] = None,
 ) -> str:
     """Generate the initial paper draft."""
     from sciresearch_workflow import (
@@ -28,10 +29,11 @@ def generate_initial_draft(
             request_timeout,
             config,
             config.initial_draft_candidates,
+            planning_brief=planning_brief,
         )
 
     return _universal_chat(
-        _initial_draft_prompt(topic, field, question, user_prompt),
+        _initial_draft_prompt(topic, field, question, user_prompt, planning_brief=planning_brief),
         model=model,
         request_timeout=request_timeout,
         prompt_type="initial_draft",

--- a/workflow_steps/research_plan.py
+++ b/workflow_steps/research_plan.py
@@ -1,0 +1,37 @@
+"""Workflow step for generating a structured research blueprint."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def generate_research_blueprint(
+    topic: str,
+    field: str,
+    question: str,
+    model: str,
+    request_timeout: int,
+    config,
+) -> Optional[str]:
+    """Generate a research blueprint prior to drafting the paper."""
+
+    if not getattr(config, "enable_blueprint_planning", True):
+        return None
+
+    from document_types import infer_document_type
+    from prompts.planning import get_blueprint_prompt
+    from sciresearch_workflow import _universal_chat
+
+    doc_type = infer_document_type(topic=topic, field=field, question=question)
+    prompt_messages = get_blueprint_prompt(doc_type, topic, field, question)
+
+    blueprint_text = _universal_chat(
+        prompt_messages,
+        model=model,
+        request_timeout=request_timeout,
+        prompt_type="research_blueprint",
+        fallback_models=getattr(config, "fallback_models", None),
+    )
+
+    return blueprint_text.strip() or None
+


### PR DESCRIPTION
## Summary
- add a research blueprint planning step before drafting and persist the plan alongside generated projects
- thread the blueprint through initial draft generation, scoring, and prompts while exposing a config/CLI flag to disable it
- refresh the README with detailed workflow documentation and highlight the new planning capability

## Testing
- python -m compileall prompts workflow_steps core/config.py sciresearch_workflow.py

------
https://chatgpt.com/codex/tasks/task_b_68d7d8bcb2a8832aa517aabc79105dc4