### PR TITLE
Respect preserve flag for simulation files

### DIFF
--- a/src/processing/files.py
+++ b/src/processing/files.py
@@ -171,8 +171,11 @@ class FileManager:
             sim_path.write_text(DEFAULT_SIMULATION_TEMPLATE, encoding="utf-8")
         elif len(py_files) == 1:
             sim_path = py_files[0]
-            # Rename to simulation.py if needed
-            if sim_path.name != "simulation.py":
+            # Rename to simulation.py if needed (unless preserving original filename)
+            if (
+                not preserve_original_filename
+                and sim_path.name != "simulation.py"
+            ):
                 new_path = project_dir / "simulation.py"
                 sim_path.rename(new_path)
                 sim_path = new_path

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -46,6 +46,25 @@ def test_ensure_single_tex_file_renames_existing_files():
         assert not custom_py.exists()
 
 
+def test_ensure_single_tex_file_preserves_filenames_when_requested():
+    """Existing files keep their original names when preservation is requested."""
+    manager = FileManager()
+    with TemporaryDirectory() as tmpdir:
+        project_dir = Path(tmpdir)
+        custom_tex = project_dir / "draft.tex"
+        custom_py = project_dir / "experiment_runner.py"
+        custom_tex.write_text("\\documentclass{article}", encoding="utf-8")
+        custom_py.write_text("print('hi')", encoding="utf-8")
+
+        paper_path, sim_path = manager.ensure_single_tex_file(
+            project_dir,
+            preserve_original_filename=True,
+        )
+
+        assert paper_path == custom_tex
+        assert sim_path == custom_py
+
+
 @pytest.mark.parametrize("ext", [".aux", ".log", ".out", ".toc", ".bbl", ".blg", ".fls", ".fdb_latexmk"])
 def test_cleanup_temp_files_removes_auxiliary_files(ext):
     """Temporary LaTeX artifacts should be cleaned up."""


### PR DESCRIPTION
## Summary
- ensure the file manager does not rename existing simulation scripts when preserve_original_filename is requested
- extend test coverage to assert both LaTeX and Python files retain their names when preservation is enabled

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d91db3338c832a9abb28ad3aed3da2