### PR TITLE
Fix DocumentTemplate import for fair scoring system

### DIFF
--- a/scoring/fair_scoring_system.py
+++ b/scoring/fair_scoring_system.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import json
 
-from document_types import DocumentType, get_document_template
+from document_types import DocumentTemplate, DocumentType, get_document_template
 from prompts.review_driven_enhancements import DomainReviewProfile, get_domain_review_profile
 from quality_enhancements.novelty_vetting import NoveltyVetter
 


### PR DESCRIPTION
## Summary
- add the missing DocumentTemplate import to the fair_scoring_system module so the scorer can be instantiated

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e89ef22784832a9b7f59daa48341b5