### PR TITLE
Run bibliography passes during LaTeX compilation

### DIFF
--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -26,12 +26,12 @@ def test_compile_and_validate_uses_cache_and_cleans_aux_files():
             assert success is True
             assert "compiled" in output
             assert not aux_file.exists()
-            mock_run.assert_called_once()
+            assert mock_run.call_count == 2
 
             cached_success, cached_output = processor.compile_and_validate(paper_path)
             assert cached_success is True
             assert cached_output == ""
-            mock_run.assert_called_once()
+            assert mock_run.call_count == 2
 
 
 def test_compile_and_validate_failure_reports_errors():


### PR DESCRIPTION
## Summary
- detect when a paper requires bibliography generation and run bibtex during compilation
- add additional pdflatex passes to incorporate references and improve cross-reference stability
- update LaTeX processor unit tests for the multi-pass compilation flow

## Testing
- pytest tests/test_latex.py

------
https://chatgpt.com/codex/tasks/task_b_68ed2302f30c832aa7713ce8b67e80cf